### PR TITLE
feat: reset demo mode on home page entry

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { auth } from "$lib/auth";
+  import { resetDemoMode } from "$lib/demo";
   import {
     PreviewCarousel,
     FeatureCard,
@@ -58,6 +59,9 @@
   }
 
   onMount(() => {
+    // Reset demo mode when entering the home page
+    resetDemoMode();
+    
     setTimeout(() => {
       recentItineraries = auth.getRecentItineraries();
       showRecent = true;


### PR DESCRIPTION
# fix(demo): reset demo mode when navigating to home page

## 概要
- デモページからホームへ戻った際にデモモードが残り、通常APIがブロックされる問題を解消。
- ホームページ読み込み時に明示的に `resetDemoMode()` を呼び出し、常に通常モードへ戻す。

## 問題の詳細
- デモページ(`/demo`)で `setDemoMode(true)` が有効化される。
- ページ遷移のタイミングによっては `onMount` のクリーンアップで `resetDemoMode()` が実行されず、ホーム復帰後もデモモードが継続。a
- `ApiClient.request()` 内で `getIsDemoMode()` が `true` を返し、`Failed to create: Error: Backend API calls are not allowed in demo mode` が発生。

## 修正内容
- `apps/web/src/routes/+page.svelte` の `onMount` でホーム表示時に `resetDemoMode()` を実行するよう追加。
- 同ファイルに `resetDemoMode` の import を追加。

## 影響範囲
- ホームページ初期化処理のみ（`apps/web/src/routes/+page.svelte`）。
- デモページ自体の挙動は維持、ホームへ戻れば必ず通常モードに復帰。

## テスト
- [ ] デモページからホームへ戻り、しおり作成・編集が正常に動作すること。
- [ ] デモページ以外からホームへアクセスしても通常通り動作すること。
- [ ] デモページ内の機能が従来どおりデモモードのまま動作すること。

## メモ
- デモモードはクライアント状態(`demoContext.ts`)で管理されるため、リロード時には自動リセットされる。本変更でホーム遷移時の取りこぼしを防止。

closes #73