### PR TITLE
Fix: map-only と mapbox-journey テーマで notes が空の場合のエラーを修正

### DIFF
--- a/apps/web/src/lib/themes/map-only/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/map-only/ItineraryView.svelte
@@ -275,7 +275,13 @@
       return;
     }
     if (onCreateStep) {
-      await onCreateStep(newStep);
+      await onCreateStep({
+        title: newStep.title.trim(),
+        date: newStep.date,
+        time: newStep.time,
+        location: newStep.location.trim() || undefined,
+        notes: newStep.notes.trim() || undefined,
+      });
       closeModals();
       resetForm();
     }
@@ -310,11 +316,11 @@
     if (!editStepId || !onUpdateStep) return;
 
     const updatedData = {
-      title: editingStepForm.title,
+      title: editingStepForm.title.trim(),
       date: editingStepForm.date,
       time: `${editStepHour}:${editStepMinute}`,
-      location: editingStepForm.location,
-      notes: editingStepForm.notes,
+      location: editingStepForm.location.trim() || undefined,
+      notes: editingStepForm.notes.trim() || undefined,
     };
 
     await onUpdateStep(editStepId, updatedData);

--- a/apps/web/src/lib/themes/mapbox-journey/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/mapbox-journey/ItineraryView.svelte
@@ -253,7 +253,13 @@
       return;
     }
     if (onCreateStep) {
-      await onCreateStep(newStep);
+      await onCreateStep({
+        title: newStep.title.trim(),
+        date: newStep.date,
+        time: newStep.time,
+        location: newStep.location.trim() || undefined,
+        notes: newStep.notes.trim() || undefined,
+      });
       closeModals();
       resetForm();
     }
@@ -287,11 +293,11 @@
     if (!editStepId || !onUpdateStep) return;
 
     const updatedData = {
-      title: editingStepForm.title,
+      title: editingStepForm.title.trim(),
       date: editingStepForm.date,
       time: `${editStepHour}:${editStepMinute}`,
-      location: editingStepForm.location,
-      notes: editingStepForm.notes,
+      location: editingStepForm.location.trim() || undefined,
+      notes: editingStepForm.notes.trim() || undefined,
     };
 
     await onUpdateStep(editStepId, updatedData);


### PR DESCRIPTION
# Fix: map-only と mapbox-journey テーマで notes が空の場合のエラーを修正

closes #75

## 概要

`map-only` および `mapbox-journey` テーマで予定を作成・編集する際、メモ欄を空欄のまま送信すると 500 エラーが発生する問題を修正しました。

## 変更内容

### 修正したファイル

- `apps/web/src/lib/themes/map-only/ItineraryView.svelte`
  - `handleAddSubmit()`: 新規作成時に `notes.trim() || undefined` を適用
  - `handleEditSubmit()`: 編集時に `notes.trim() || undefined` を適用
  
- `apps/web/src/lib/themes/mapbox-journey/ItineraryView.svelte`
  - `handleAddSubmit()`: 新規作成時に `notes.trim() || undefined` を適用
  - `handleEditSubmit()`: 編集時に `notes.trim() || undefined` を適用

### 修正内容

```typescript
// 修正前
await onCreateStep(newStep);

// 修正後
await onCreateStep({
  title: newStep.title.trim(),
  date: newStep.date,
  time: newStep.time,
  location: newStep.location.trim() || undefined,
  notes: newStep.notes.trim() || undefined,
});
```

## 問題の原因

1. フロントエンドから `notes: ""` (空文字列) が送信される
2. バックエンドの `??` 演算子は `null` または `undefined` のみをデフォルト値に変換
3. 空文字列はそのまま通過してバリデーションエラーになる

## テスト

### 確認項目

- [x] map-only テーマでメモ欄が空欄で予定作成 → 成功
- [x] map-only テーマでメモ欄が空欄で予定編集 → 成功
- [x] mapbox-journey テーマでメモ欄が空欄で予定作成 → 成功
- [x] mapbox-journey テーマでメモ欄が空欄で予定編集 → 成功
- [x] メモ欄にテキストを入力した場合も正常動作

### 既存テーマへの影響

- standard-autumn, ai-generated, minimal テーマは既に同じパターンで実装済みのため影響なし

## 関連

- 参考実装: `apps/web/src/lib/themes/standard-autumn/ItineraryView.svelte`
- バックエンド: `apps/api/src/services/step.service.ts`
- バリデーション: `apps/api/src/utils/memo.ts`
