### PR TITLE
feat(sauna-rally): add home button to theme

### DIFF
--- a/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
@@ -203,6 +203,18 @@
 </script>
 
 <div class="sauna-rally-container">
+  <a class="sauna-home-button" href="/" aria-label="ホーム">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      width="20"
+      height="20"
+    >
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    </svg>
+  </a>
+
   <header class="sauna-header">
     <div class="header-top">
       {#if isEditingTitle}

--- a/apps/web/src/lib/themes/sauna-rally/styles/index.css
+++ b/apps/web/src/lib/themes/sauna-rally/styles/index.css
@@ -7,12 +7,42 @@
   background-attachment: fixed;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
     Arial, sans-serif;
+  position: relative;
+}
+
+.sauna-home-button {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: 100;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #ff6b35;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.sauna-home-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  background: #fff;
+}
+
+.sauna-home-button:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
 .sauna-header {
   background: linear-gradient(135deg, #ff6b35 0%, #ff8c5a 100%);
   color: white;
-  padding: 1rem 1.5rem;
+  padding: 1rem 1.5rem 1rem 5rem;
   box-shadow: 0 4px 12px rgba(255, 107, 53, 0.3);
   position: sticky;
   top: 0;


### PR DESCRIPTION
# feat(sauna-rally): add home button to theme

## 概要
sauna-rallyテーマにホームへ戻るボタンを追加しました。

## 変更内容
- 左上にホームボタンを配置
- ホームアイコン（家のマーク）を使用
- ホバー時のアニメーション効果を追加
- ヘッダーの左パディングを調整し、タイトルとの重なりを防止

## 実装詳細
### 追加したファイル
- `apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte`
  - ホームボタンのマークアップを追加
  
- `apps/web/src/lib/themes/sauna-rally/styles/index.css`
  - ホームボタンのスタイル定義を追加
  - ヘッダーの左パディングを `1rem` → `5rem` に変更

## スクリーンショット
ホームボタンは左上に固定配置され、他のテーマと統一されたデザインになっています。

## 関連Issue
Closes #82
