### PR TITLE
feat(sauna-theme): サウナスタンプラリーテーマに編集/閲覧モード切り替え機能を追加

### DIFF
--- a/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
@@ -53,6 +53,7 @@
   let editedTitle = $state(itinerary.title);
   let isAddingSauna = $state(false);
   let hasEditPermission = $state(false);
+  let isViewMode = $state(false);
   let showPasswordDialog = $state(false);
   let showThemeSelect = $state(false);
   let password = $state("");
@@ -73,6 +74,13 @@
       return {};
     }
     return {};
+  }
+
+  function toggleViewMode() {
+    if (!hasEditPermission) return;
+    isViewMode = !isViewMode;
+    isAddingSauna = false;
+    showThemeSelect = false;
   }
 
   onMount(() => {
@@ -227,22 +235,25 @@
           placeholder="サウナ旅のタイトル"
         />
       {:else}
-        <h1 class="rally-title" onclick={() => hasEditPermission && (isEditingTitle = true)}>
+        <h1 class="rally-title" onclick={() => hasEditPermission && !isViewMode && (isEditingTitle = true)}>
           {itinerary.title}
         </h1>
       {/if}
 
       <div class="header-actions">
         {#if hasEditPermission}
-          <button class="add-sauna-button-header" onclick={() => (isAddingSauna = true)}>
-            + サウナ追加
+          <button class="view-mode-toggle-button" onclick={toggleViewMode}>
+            {isViewMode ? '編集モード' : '閲覧モード'}
           </button>
-          <button class="theme-button" onclick={() => (showThemeSelect = !showThemeSelect)}>
-            テーマ変更
-          </button>
-        {/if}
-
-        {#if !hasEditPermission}
+          {#if !isViewMode}
+            <button class="add-sauna-button-header" onclick={() => (isAddingSauna = true)}>
+              + サウナ追加
+            </button>
+            <button class="theme-button" onclick={() => (showThemeSelect = !showThemeSelect)}>
+              テーマ変更
+            </button>
+          {/if}
+        {:else}
           <button class="edit-button" onclick={attemptEditModeActivation}>
             編集モード
           </button>
@@ -255,6 +266,7 @@
     <StepList
       {steps}
       {hasEditPermission}
+      {isViewMode}
       onAddSauna={() => (isAddingSauna = true)}
       {onUpdateStep}
       {onDeleteStep}

--- a/apps/web/src/lib/themes/sauna-rally/StepList.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/StepList.svelte
@@ -4,6 +4,7 @@
   interface Props {
     steps: Step[];
     hasEditPermission: boolean;
+    isViewMode: boolean;
     onAddSauna?: () => void;
     onUpdateStep?: (
       stepId: string,
@@ -18,7 +19,7 @@
     onDeleteStep?: (stepId: string) => Promise<void>;
   }
 
-  let { steps, hasEditPermission, onAddSauna, onUpdateStep, onDeleteStep }: Props = $props();
+  let { steps, hasEditPermission, isViewMode, onAddSauna, onUpdateStep, onDeleteStep }: Props = $props();
 
   interface SaunaData {
     visited?: boolean;
@@ -50,7 +51,7 @@
     event.preventDefault();
     event.stopPropagation();
     
-    if (!hasEditPermission || !onUpdateStep) return;
+    if (!onUpdateStep) return;
 
     const data = getSaunaData(step);
     const newData: SaunaData = {
@@ -182,15 +183,15 @@
             {/if}
           </div>
 
-          {#if hasEditPermission}
-            <div class="stamp-card-actions">
-              <button
-                class="complete-button"
-                class:undo={isVisited}
-                onclick={(e) => toggleVisited(step, e)}
-              >
-                {isVisited ? '取消' : '完了'}
-              </button>
+          <div class="stamp-card-actions">
+            <button
+              class="complete-button"
+              class:undo={isVisited}
+              onclick={(e) => toggleVisited(step, e)}
+            >
+              {isVisited ? '取消' : '完了'}
+            </button>
+            {#if hasEditPermission && !isViewMode}
               <button
                 class="edit-icon-button"
                 onclick={(e) => startEdit(step, e)}
@@ -209,8 +210,8 @@
               >
                 🗑️
               </button>
-            </div>
-          {/if}
+            {/if}
+          </div>
         {:else}
           <div
             class="edit-form-inline"

--- a/apps/web/src/lib/themes/sauna-rally/styles/index.css
+++ b/apps/web/src/lib/themes/sauna-rally/styles/index.css
@@ -146,6 +146,23 @@
   background: rgba(255, 255, 255, 0.3);
 }
 
+.view-mode-toggle-button {
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  color: #ff6b35;
+  border: 2px solid white;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.view-mode-toggle-button:hover {
+  background: white;
+  color: #ff5722;
+}
+
 .add-sauna-button-header {
   padding: 0.5rem 1rem;
   background: white;


### PR DESCRIPTION
# サウナスタンプラリーテーマに編集/閲覧モード切り替え機能を追加

## 概要

サウナスタンプラリーテーマに、他のテーマと同様の編集/閲覧モード切り替え機能を追加しました。
また、閲覧モードでもスタンプの完了/未完了操作ができるようにUXを改善しました。

## 関連Issue

Closes #89

## 変更内容

### 🎯 主な機能追加

1. **編集/閲覧モード切り替えボタンの追加**
   - 編集権限がある場合、ヘッダーにモード切り替えボタンを表示
   - 編集モード → 閲覧モード、閲覧モード → 編集モード の切り替えが可能
   - 他のテーマ（map-only、mapbox-journey、standard-autumn等）と一貫したUX

2. **閲覧モードでのスタンプ操作を許可**
   - 従来: 閲覧モードではスタンプの完了/未完了ボタンが非表示
   - 改善: 閲覧モードでもスタンプの完了/未完了ボタンを表示し、操作可能に
   - 訪問記録の更新という観点から、閲覧者でも操作できる方が便利

3. **閲覧モードでの制限**
   - サウナ追加ボタン: 非表示
   - テーマ変更ボタン: 非表示
   - 施設編集ボタン: 非表示
   - 施設削除ボタン: 非表示
   - タイトル編集: 無効

### 📝 実装詳細

#### `apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte`

```diff
+ let isViewMode = $state(false);

+ function toggleViewMode() {
+   if (!hasEditPermission) return;
+   isViewMode = !isViewMode;
+   isAddingSauna = false;
+   showThemeSelect = false;
+ }

  <div class="header-actions">
    {#if hasEditPermission}
+     <button class="view-mode-toggle-button" onclick={toggleViewMode}>
+       {isViewMode ? '編集モード' : '閲覧モード'}
+     </button>
+     {#if !isViewMode}
        <button class="add-sauna-button-header" ...>
        <button class="theme-button" ...>
+     {/if}
    {/if}
  </div>

  <StepList
    {steps}
    {hasEditPermission}
+   {isViewMode}
    ...
  />
```

#### `apps/web/src/lib/themes/sauna-rally/StepList.svelte`

```diff
  interface Props {
    steps: Step[];
    hasEditPermission: boolean;
+   isViewMode: boolean;
    ...
  }

  async function toggleVisited(step: Step, event: MouseEvent) {
    event.preventDefault();
    event.stopPropagation();
    
-   if (!hasEditPermission || !onUpdateStep) return;
+   if (!onUpdateStep) return;
    ...
  }

- {#if hasEditPermission}
    <div class="stamp-card-actions">
      <button class="complete-button" ...>
        {isVisited ? '取消' : '完了'}
      </button>
+     {#if hasEditPermission && !isViewMode}
        <button class="edit-icon-button" ...>✏️</button>
        <button class="delete-icon-button" ...>🗑️</button>
+     {/if}
    </div>
- {/if}
```

#### `apps/web/src/lib/themes/sauna-rally/styles/index.css`

```css
.view-mode-toggle-button {
  padding: 0.5rem 1rem;
  background: rgba(255, 255, 255, 0.95);
  color: #ff6b35;
  border: 2px solid white;
  border-radius: 8px;
  font-weight: 600;
  cursor: pointer;
  transition: all 0.3s ease;
  white-space: nowrap;
}

.view-mode-toggle-button:hover {
  background: white;
  color: #ff5722;
}
```

## UI/UX

### 編集モード
- ✅ スタンプ完了/未完了ボタン表示
- ✅ 施設編集ボタン表示
- ✅ 施設削除ボタン表示
- ✅ サウナ追加ボタン表示
- ✅ テーマ変更ボタン表示
- ✅ タイトル編集可能

### 閲覧モード
- ✅ スタンプ完了/未完了ボタン表示（**新機能**）
- ❌ 施設編集ボタン非表示
- ❌ 施設削除ボタン非表示
- ❌ サウナ追加ボタン非表示
- ❌ テーマ変更ボタン非表示
- ❌ タイトル編集不可

### ボタン配置

```
編集モード時:
[タイトル]  [閲覧モード] [+ サウナ追加] [テーマ変更]

閲覧モード時:
[タイトル]  [編集モード]
```

## テスト

### 手動テスト実施項目

- [x] 編集権限がある場合、モード切り替えボタンが表示される
- [x] モード切り替えボタンをクリックすると、編集/閲覧モードが切り替わる
- [x] 閲覧モードでスタンプの完了/未完了ボタンが表示され、動作する
- [x] 閲覧モードで編集・削除・追加ボタンが非表示になる
- [x] 閲覧モードでスタンプをクリックして外部リンクに移動できる
- [x] 閲覧モードでタイトル編集ができない
- [x] 他のテーマから閲覧モードで移動しても適切に動作する

### 自動テスト

今後、Playwright E2Eテストで以下をカバーする予定:
- 編集/閲覧モード切り替えの動作
- 各モードでのボタン表示/非表示の確認
- 閲覧モードでのスタンプ操作

## スクリーンショット

### 編集モード
ヘッダーに「閲覧モード」ボタンと「サウナ追加」「テーマ変更」ボタンが表示され、スタンプカードには編集・削除ボタンが表示されます。

### 閲覧モード
ヘッダーには「編集モード」ボタンのみ表示され、スタンプカードには完了/取消ボタンのみ表示されます。

## チェックリスト

- [x] コードが正しく動作することを確認
- [x] コミットメッセージがConventional Commitsに準拠
- [x] 変更内容が他のテーマと一貫性がある
- [x] アクセシビリティ警告を確認（既存の警告のみ）
- [x] 型エラーがないことを確認
- [ ] E2Eテストを追加（今後の課題）
- [ ] ドキュメントを更新（必要に応じて）

## 補足

この変更により、サウナテーマでも他のテーマと一貫したUX/UIが提供されるようになりました。
特に、閲覧モードでのスタンプ操作は、訪問記録の更新という観点から合理的な改善です。

テーマ間の移動時にモード状態が適切に処理されることを確認済みです。
