### PR TITLE
fix: エラー時に loading フラグがリセットされない問題を修正

### DIFF
--- a/apps/web/src/routes/demo/+page.svelte
+++ b/apps/web/src/routes/demo/+page.svelte
@@ -68,6 +68,7 @@
 
       if (!itinerary) {
         error = "デモデータの読み込みに失敗しました";
+        loading = false;
         return;
       }
 
@@ -77,6 +78,7 @@
     } catch (e) {
       console.error("Failed to load demo:", e);
       error = "デモの読み込みに失敗しました";
+      loading = false;
     }
 
     return () => {


### PR DESCRIPTION
## Summary

- `itinerary` が null の場合の early return 前に `loading = false` を追加
- `catch` ブロックにも `loading = false` を追加

Closes #118

## Test plan

- [ ] デモページでネットワークエラーをシミュレートし、ローディング画面が消えてエラーメッセージが表示されることを確認
- [ ] デモデータの読み込みに失敗した際（localStorage 破損等）に、エラー画面が正しく表示されることを確認
- [ ] 正常なデモ読み込みが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)