### PR TITLE
feat(sauna): パスワード認証をコンポーネント化して編集パスワード機能を整備

### DIFF
--- a/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
@@ -9,6 +9,7 @@
   import { onMount } from "svelte";
   import StepList from "./StepList.svelte";
   import "./styles/index.css";
+  import PasswordDialog from "./components/PasswordDialog.svelte";
   import ShareDialog from "./components/ShareDialog.svelte";
 
   interface Props {
@@ -18,6 +19,11 @@
       title?: string;
       theme_id?: string;
       memo?: string;
+      walica_id?: string | null;
+      secret_settings?: {
+        enabled: boolean;
+        offset_minutes: number;
+      } | null;
     }) => Promise<void>;
     onCreateStep?: (data: {
       title: string;
@@ -57,10 +63,9 @@
   let isViewMode = $state(false);
   let showPasswordDialog = $state(false);
   let showThemeSelect = $state(false);
-  let password = $state("");
-  let isAuthenticating = $state(false);
   let showShareDialog = $state(false);
   let showCopyMessage = $state(false);
+  let passwordDialogAuthenticating = $state(false);
 
   interface SaunaData {
     visited?: boolean;
@@ -100,7 +105,7 @@
     auth.updateAccessTime(itinerary.id, itinerary.title);
   });
 
-  async function onPasswordAuth() {
+  async function onPasswordAuth(password: string) {
     await handlePasswordAuth({
       shioriId: itinerary.id,
       title: itinerary.title,
@@ -108,10 +113,9 @@
       onSuccess: () => {
         hasEditPermission = true;
         showPasswordDialog = false;
-        password = "";
       },
       onError: (message) => alert(message),
-      setAuthenticating: (value) => (isAuthenticating = value),
+      setAuthenticating: (value) => (passwordDialogAuthenticating = value),
     });
   }
 
@@ -356,40 +360,16 @@
   onClose={() => (showShareDialog = false)}
 />
 
+<PasswordDialog
+  show={showPasswordDialog}
+  isAuthenticating={passwordDialogAuthenticating}
+  onAuth={onPasswordAuth}
+  onClose={() => (showPasswordDialog = false)}
+/>
+
 {#if showCopyMessage}
   <div class="sauna-copy-message">
     🔗 リンクをコピーしました!
-  </div>
-{/if}
-
-{#if showPasswordDialog}
-  <div class="modal-overlay" onclick={() => (showPasswordDialog = false)}>
-    <div class="modal-content" onclick={(e) => e.stopPropagation()}>
-      <h2>パスワード入力</h2>
-      <p>このしおりを編集するにはパスワードが必要です</p>
-      <input
-        type="password"
-        bind:value={password}
-        placeholder="パスワード"
-        class="password-input"
-        onkeydown={(e) => e.key === "Enter" && onPasswordAuth()}
-      />
-      <div class="modal-actions">
-        <button
-          class="button-secondary"
-          onclick={() => (showPasswordDialog = false)}
-        >
-          キャンセル
-        </button>
-        <button
-          class="button-primary"
-          onclick={onPasswordAuth}
-          disabled={isAuthenticating}
-        >
-          {isAuthenticating ? "確認中..." : "確認"}
-        </button>
-      </div>
-    </div>
   </div>
 {/if}
 
@@ -440,33 +420,3 @@
   </div>
 {/if}
 
-{#if showPasswordDialog}
-  <div class="modal-overlay" onclick={() => (showPasswordDialog = false)}>
-    <div class="modal-content" onclick={(e) => e.stopPropagation()}>
-      <h2>パスワード入力</h2>
-      <p>このしおりを編集するにはパスワードが必要です</p>
-      <input
-        type="password"
-        bind:value={password}
-        placeholder="パスワード"
-        class="password-input"
-        onkeydown={(e) => e.key === "Enter" && onPasswordAuth()}
-      />
-      <div class="modal-actions">
-        <button
-          class="button-secondary"
-          onclick={() => (showPasswordDialog = false)}
-        >
-          キャンセル
-        </button>
-        <button
-          class="button-primary"
-          onclick={onPasswordAuth}
-          disabled={isAuthenticating}
-        >
-          {isAuthenticating ? "確認中..." : "確認"}
-        </button>
-      </div>
-    </div>
-  </div>
-{/if} 

--- a/apps/web/src/lib/themes/sauna-rally/components/PasswordDialog.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/components/PasswordDialog.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  interface Props {
+    show: boolean;
+    isAuthenticating: boolean;
+    onAuth: (password: string) => void;
+    onClose: () => void;
+  }
+
+  let { show, isAuthenticating, onAuth, onClose }: Props = $props();
+
+  let password = $state("");
+
+  function handleSubmit() {
+    onAuth(password);
+    password = "";
+  }
+
+  function handleClose() {
+    password = "";
+    onClose();
+  }
+</script>
+
+{#if show}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="sauna-password-overlay" onclick={handleClose}>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="sauna-password-dialog" onclick={(e) => e.stopPropagation()}>
+      <h3 class="sauna-password-dialog-title">🔐 パスワード入力</h3>
+      <p class="sauna-password-dialog-desc">このしおりを編集するにはパスワードが必要です</p>
+
+      <form
+        onsubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <input
+          type="password"
+          bind:value={password}
+          placeholder="パスワードを入力"
+          class="sauna-password-input"
+          disabled={isAuthenticating}
+        />
+
+        <div class="sauna-dialog-actions">
+          <button
+            type="button"
+            class="sauna-btn sauna-btn-secondary"
+            onclick={handleClose}
+            disabled={isAuthenticating}
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            class="sauna-btn sauna-btn-primary"
+            disabled={isAuthenticating}
+          >
+            {isAuthenticating ? "確認中..." : "確認"}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .sauna-password-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  .sauna-password-dialog {
+    background: white;
+    border-radius: 16px;
+    padding: 24px;
+    max-width: 400px;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  }
+
+  .sauna-password-dialog-title {
+    margin: 0 0 8px 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #1a1a1a;
+  }
+
+  .sauna-password-dialog-desc {
+    margin: 0 0 20px 0;
+    font-size: 14px;
+    color: #666;
+  }
+
+  .sauna-password-input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 16px;
+    font-family: inherit;
+    box-sizing: border-box;
+    margin-bottom: 20px;
+    transition: border-color 0.2s ease;
+  }
+
+  .sauna-password-input:focus {
+    outline: none;
+    border-color: #ff6b35;
+  }
+
+  .sauna-dialog-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+  }
+
+  .sauna-btn {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 8px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: inherit;
+    font-size: 14px;
+  }
+
+  .sauna-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .sauna-btn-primary {
+    background: linear-gradient(135deg, #ff6b35 0%, #ff8c5a 100%);
+    color: white;
+  }
+
+  .sauna-btn-primary:hover:not(:disabled) {
+    box-shadow: 0 4px 12px rgba(255, 107, 53, 0.4);
+    transform: translateY(-1px);
+  }
+
+  .sauna-btn-secondary {
+    background: #f0f0f0;
+    color: #1a1a1a;
+  }
+
+  .sauna-btn-secondary:hover:not(:disabled) {
+    background: #e0e0e0;
+  }
+</style>


### PR DESCRIPTION
## Summary

- `PasswordDialog` コンポーネントを新規作成（サウナテーマのデザインに統一したスタイル）
- `ItineraryView` のインライン実装を `PasswordDialog` コンポーネントに置き換え
- 重複していた `{#if showPasswordDialog}` ブロック（2箇所）を削除
- `Props` に `walica_id` / `secret_settings` を追加（他テーマとのインターフェースを統一）

Closes #114

## Test plan

- [ ] パスワード保護されたしおりを sauna テーマで開き、「編集モード」ボタンを押してパスワードダイアログが表示されることを確認
- [ ] 正しいパスワードを入力して編集モードに入れることを確認
- [ ] 誤ったパスワードでエラーが表示されることを確認
- [ ] キャンセルボタンでダイアログが閉じることを確認
- [ ] パスワード未設定のしおりで直接編集モードに入れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)