### PR TITLE
fix(api): remove observability from deploy template

### DIFF
--- a/apps/api/wrangler.toml.example
+++ b/apps/api/wrangler.toml.example
@@ -2,9 +2,6 @@ name = "tabitabi-api"
 main = "src/index.ts"
 compatibility_date = "2024-09-17"
 
-[observability]
-enabled = true
-
 [[d1_databases]]
 binding = "DB"
 database_name = "tabitabi"
@@ -21,9 +18,6 @@ name = "tabitabi-api"
 ALLOWED_ORIGINS = "https://tabitabi.pages.dev"
 JWT_SECRET = "PLACEHOLDER_PROD_SECRET"
 
-[env.production.observability]
-enabled = true
-
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "tabitabi"
@@ -34,9 +28,6 @@ migrations_dir = "./migrations"
 
 [env.preview.vars]
 ALLOWED_ORIGINS = "*"
-
-[env.preview.observability]
-enabled = true
 
 [[env.preview.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- remove \[observability\] blocks from apps/api/wrangler.toml.example
- prevent production API deploy from sending script-settings update that intermittently returns 502

## Background
GitHub Actions failed on 
Cloudflare collects anonymous telemetry about your usage of Wrangler. Learn more at https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md

 ⛅️ wrangler 4.47.0 (update available 4.71.0)
───────────────────────────────────────────── with:
- 

The deploy workflow generates  from , so this template fix is what matters in CI.

## Validation
- pnpm --filter api test:run (passed)
- cd apps/api && pnpm wrangler deploy --env production --dry-run (passed)
