### PR TITLE
feat(standard-seasons): consolidate icons, add transport demo data, fix week view & time validation

### DIFF
--- a/apps/web/src/lib/themes/catalog.ts
+++ b/apps/web/src/lib/themes/catalog.ts
@@ -1,4 +1,4 @@
-export const defaultThemeId = "standard-autumn" as const;
+export const defaultThemeId = "standard-spring" as const;
 
 export const availableThemes = [
   "map-only",

--- a/apps/web/src/lib/themes/standard-seasons/autumn/demo-data.ts
+++ b/apps/web/src/lib/themes/standard-seasons/autumn/demo-data.ts
@@ -35,6 +35,18 @@ export function getDemoData(): DemoDataSet {
         updated_at: now,
       },
       {
+        id: 'demo-step-2-transport',
+        itinerary_id: 'demo',
+        title: '湯滝から華厳滝へ移動',
+        start_at: getTimestamp(0, '13:30'),
+        end_at: getEndTimestamp(getTimestamp(0, '13:30'), 60),
+        location: '中禅寺湖周辺',
+        notes: '{"text":"バスでの移動を想定"}',
+        type: 'transport:bus',
+        created_at: now,
+        updated_at: now,
+      },
+      {
         id: 'demo-step-3',
         itinerary_id: 'demo',
         title: '華厳滝',

--- a/apps/web/src/lib/themes/standard-seasons/autumn/styles/variables.css
+++ b/apps/web/src/lib/themes/standard-seasons/autumn/styles/variables.css
@@ -1,0 +1,7 @@
+/* Autumn theme variables (delegates to shared variables by default)
+   Add season-specific overrides here when appropriate */
+@import '../../shared/styles/variables.css';
+
+:root {
+  /* Autumn-specific overrides can be placed here */
+}

--- a/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
@@ -270,7 +270,11 @@
     isEditingTitle = false;
   }
 
-  async function handleAddStep(payload?: { start_at?: number; end_at?: number; type?: StepType }) {
+  async function handleAddStep(payload?: {
+    start_at?: number;
+    end_at?: number;
+    type?: StepType;
+  }) {
     if (!newStep.title.trim()) {
       alert("タイトル、日付は必須です");
       return;
@@ -369,9 +373,10 @@
     }
   }
   function buildThemeOverrideStyle(themeId: string): string {
-    const season = themeId && themeId.startsWith("standard-")
-      ? themeId.replace("standard-", "")
-      : "autumn";
+    const season =
+      themeId && themeId.startsWith("standard-")
+        ? themeId.replace("standard-", "")
+        : "autumn";
     const props = [
       "bg",
       "primary",

--- a/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
@@ -270,21 +270,42 @@
     isEditingTitle = false;
   }
 
-  async function handleAddStep() {
-    if (!newStep.title.trim() || !newStep.date || !newStep.time) {
-      alert("タイトル、日付、時刻は必須です");
+  async function handleAddStep(payload?: { start_at?: number; end_at?: number; type?: StepType }) {
+    if (!newStep.title.trim()) {
+      alert("タイトル、日付は必須です");
       return;
     }
-    if (onCreateStep) {
-      const startAt = createTimestamp(newStep.date, newStep.time);
+
+    let startAt: number | undefined = undefined;
+    let endAt: number | undefined = undefined;
+
+    if (payload && payload.start_at) {
+      startAt = payload.start_at;
+      endAt = payload.end_at ?? createEndTimestamp(startAt, 60);
+    } else {
+      if (!newStep.date || !newStep.time) {
+        alert("日時の指定が正しくありません");
+        return;
+      }
+      startAt = createTimestamp(newStep.date, newStep.time);
+      endAt = createEndTimestamp(startAt, 60);
+    }
+
+    if (endAt <= startAt) {
+      alert("終了時刻は開始時刻より後にしてください");
+      return;
+    }
+
+    if (onCreateStep && startAt) {
       await onCreateStep({
         title: newStep.title.trim(),
         start_at: startAt,
-        end_at: createEndTimestamp(startAt, 60),
+        end_at: endAt,
         location: newStep.location.trim() || undefined,
         notes: newStep.notes.trim() || undefined,
-        type: newStep.type,
+        type: payload?.type ?? newStep.type,
       });
+
       newStep = {
         title: "",
         date: "",
@@ -347,6 +368,30 @@
       await onUpdateItinerary({ walica_id: walicaId });
     }
   }
+  function buildThemeOverrideStyle(themeId: string): string {
+    const season = themeId && themeId.startsWith("standard-")
+      ? themeId.replace("standard-", "")
+      : "autumn";
+    const props = [
+      "bg",
+      "primary",
+      "primary-light",
+      "secondary",
+      "accent",
+      "text",
+      "text-light",
+      "card-bg",
+      "header-bg",
+      "border",
+      "line-color",
+      "dot-bg",
+      "shadow",
+      "shadow-sm",
+    ];
+    return props
+      .map((p) => `--standard-autumn-${p}: var(--standard-${season}-${p})`)
+      .join("; ");
+  }
 </script>
 
 <div
@@ -354,92 +399,7 @@
   class:standard-spring-theme={selectedThemeId === "standard-spring"}
   class:standard-summer-theme={selectedThemeId === "standard-summer"}
   class:standard-winter-theme={selectedThemeId === "standard-winter"}
-  style="
-    --standard-autumn-bg: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-bg)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-bg)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-bg)'
-        : 'var(--standard-autumn-bg)'};
-    --standard-autumn-primary: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-primary)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-primary)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-primary)'
-        : 'var(--standard-autumn-primary)'};
-    --standard-autumn-primary-light: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-primary-light)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-primary-light)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-primary-light)'
-        : 'var(--standard-autumn-primary-light)'};
-    --standard-autumn-secondary: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-secondary)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-secondary)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-secondary)'
-        : 'var(--standard-autumn-secondary)'};
-    --standard-autumn-accent: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-accent)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-accent)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-accent)'
-        : 'var(--standard-autumn-accent)'};
-    --standard-autumn-text: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-text)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-text)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-text)'
-        : 'var(--standard-autumn-text)'};
-    --standard-autumn-text-light: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-text-light)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-text-light)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-text-light)'
-        : 'var(--standard-autumn-text-light)'};
-    --standard-autumn-border: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-border)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-border)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-border)'
-        : 'var(--standard-autumn-border)'};
-    --standard-autumn-line-color: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-line-color)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-line-color)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-line-color)'
-        : 'var(--standard-autumn-line-color)'};
-    --standard-autumn-dot-bg: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-dot-bg)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-dot-bg)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-dot-bg)'
-        : 'var(--standard-autumn-dot-bg)'};
-    --standard-autumn-shadow: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-shadow)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-shadow)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-shadow)'
-        : 'var(--standard-autumn-shadow)'};
-    --standard-autumn-shadow-sm: {selectedThemeId === 'standard-spring'
-    ? 'var(--standard-spring-shadow-sm)'
-    : selectedThemeId === 'standard-summer'
-      ? 'var(--standard-summer-shadow-sm)'
-      : selectedThemeId === 'standard-winter'
-        ? 'var(--standard-winter-shadow-sm)'
-        : 'var(--standard-autumn-shadow-sm)'};
-  "
+  style={buildThemeOverrideStyle(selectedThemeId)}
 >
   <div class="standard-autumn-container">
     <header class="standard-autumn-header">

--- a/apps/web/src/lib/themes/standard-seasons/shared/StepList.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/StepList.svelte
@@ -523,10 +523,12 @@
                     <div class="standard-autumn-timeline-line"></div>
                     <div class="standard-autumn-step-dot"></div>
 
-                      {#if isSecretStep(step) && !hasEditPermission}
+                    {#if isSecretStep(step) && !hasEditPermission}
                       <div
                         class="standard-autumn-step-content standard-autumn-step-hidden"
-                        class:standard-autumn-step-transport={isTransportType(step.type)}
+                        class:standard-autumn-step-transport={isTransportType(
+                          step.type,
+                        )}
                         onclick={() => handleStepClick(step.id)}
                         role="button"
                         tabindex="0"
@@ -557,10 +559,12 @@
                           <div class="standard-autumn-secret-line short"></div>
                         </div>
                       </div>
-                      {:else}
+                    {:else}
                       <div
                         class="standard-autumn-step-content"
-                        class:standard-autumn-step-transport={isTransportType(step.type)}
+                        class:standard-autumn-step-transport={isTransportType(
+                          step.type,
+                        )}
                         onclick={() => handleStepClick(step.id)}
                         role="button"
                         tabindex="0"
@@ -577,14 +581,23 @@
                             <IconRenderer type={step.type} size="sm" />
                           </div>
                         </div>
-                          {#if isTransportType(step.type)}
-                            <div class="standard-autumn-transport-overlay" aria-hidden="true">
-                              <div class="moving-vehicle">
-                                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M3 12h18v2H3z"/></svg>
-                              </div>
-                              <div class="moving-trail" />
+                        {#if isTransportType(step.type)}
+                          <div
+                            class="standard-autumn-transport-overlay"
+                            aria-hidden="true"
+                          >
+                            <div class="moving-vehicle">
+                              <svg
+                                viewBox="0 0 24 24"
+                                width="18"
+                                height="18"
+                                fill="currentColor"
+                                ><path d="M3 12h18v2H3z" /></svg
+                              >
                             </div>
-                          {/if}
+                            <div class="moving-trail"></div>
+                          </div>
+                        {/if}
                         {#if step.location}
                           <div class="standard-autumn-step-location">
                             <svg

--- a/apps/web/src/lib/themes/standard-seasons/shared/StepList.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/StepList.svelte
@@ -17,6 +17,7 @@
     ChevronRightIcon,
   } from "./components/icons/index.svelte";
   import IconRenderer from "./icons/IconRenderer.svelte";
+  import { isTransportType } from "./utils/step-type";
   import { type ViewMode } from "./utils/storage";
   import { ListView, MonthView, WeekView } from "./views";
   import EventDetailDialog from "./components/EventDetailDialog.svelte";
@@ -522,9 +523,10 @@
                     <div class="standard-autumn-timeline-line"></div>
                     <div class="standard-autumn-step-dot"></div>
 
-                    {#if isSecretStep(step) && !hasEditPermission}
+                      {#if isSecretStep(step) && !hasEditPermission}
                       <div
                         class="standard-autumn-step-content standard-autumn-step-hidden"
+                        class:standard-autumn-step-transport={isTransportType(step.type)}
                         onclick={() => handleStepClick(step.id)}
                         role="button"
                         tabindex="0"
@@ -555,9 +557,10 @@
                           <div class="standard-autumn-secret-line short"></div>
                         </div>
                       </div>
-                    {:else}
+                      {:else}
                       <div
                         class="standard-autumn-step-content"
+                        class:standard-autumn-step-transport={isTransportType(step.type)}
                         onclick={() => handleStepClick(step.id)}
                         role="button"
                         tabindex="0"
@@ -574,6 +577,14 @@
                             <IconRenderer type={step.type} size="sm" />
                           </div>
                         </div>
+                          {#if isTransportType(step.type)}
+                            <div class="standard-autumn-transport-overlay" aria-hidden="true">
+                              <div class="moving-vehicle">
+                                <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M3 12h18v2H3z"/></svg>
+                              </div>
+                              <div class="moving-trail" />
+                            </div>
+                          {/if}
                         {#if step.location}
                           <div class="standard-autumn-step-location">
                             <svg

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/AddStepForm.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/AddStepForm.svelte
@@ -36,7 +36,9 @@
 
   // End time state for the form (allow specifying end time when creating)
   let newStepEndDate = $state(newStep.date || "");
-  let newStepEndHour = $state(String((parseInt(newStepHour || "09", 10) + 1) % 24).padStart(2, "0"));
+  let newStepEndHour = $state(
+    String((parseInt(newStepHour || "09", 10) + 1) % 24).padStart(2, "0"),
+  );
   let newStepEndMinute = $state(newStepMinute || "00");
   let startUserChanged = $state(false);
   let endUserChanged = $state(false);
@@ -53,7 +55,10 @@
     // compute default end from start
     if (!newStep.date || !newStepHour || !newStepMinute) return;
     try {
-      const startAt = createTimestamp(newStep.date, `${newStepHour}:${newStepMinute}`);
+      const startAt = createTimestamp(
+        newStep.date,
+        `${newStepHour}:${newStepMinute}`,
+      );
       const endAt = createEndTimestamp(startAt, DEFAULT_DURATION_MIN);
       const d = new Date(endAt);
       newStepEndDate = d.toISOString().split("T")[0];
@@ -66,13 +71,24 @@
 
   function handleSubmit(e: Event) {
     e.preventDefault();
-    if (!newStep.title.trim() || !newStep.date || !newStepHour || !newStepMinute) {
+    if (
+      !newStep.title.trim() ||
+      !newStep.date ||
+      !newStepHour ||
+      !newStepMinute
+    ) {
       alert("タイトル、日付、時刻は必須です");
       return;
     }
 
-    const startAt = createTimestamp(newStep.date, `${newStepHour}:${newStepMinute}`);
-    const endAt = createTimestamp(newStepEndDate || newStep.date, `${newStepEndHour}:${newStepEndMinute}`);
+    const startAt = createTimestamp(
+      newStep.date,
+      `${newStepHour}:${newStepMinute}`,
+    );
+    const endAt = createTimestamp(
+      newStepEndDate || newStep.date,
+      `${newStepEndHour}:${newStepEndMinute}`,
+    );
 
     if (endAt <= startAt) {
       alert("終了時刻は開始時刻より後にしてください");
@@ -97,14 +113,14 @@
       <input
         type="date"
         bind:value={newStep.date}
-        on:change={() => (startUserChanged = true)}
+        onchange={() => (startUserChanged = true)}
         class="standard-autumn-input"
         required
       />
       <div class="standard-autumn-time-picker">
         <select
           bind:value={newStepHour}
-          on:change={() => (startUserChanged = true)}
+          onchange={() => (startUserChanged = true)}
           class="standard-autumn-select-time"
           required
         >
@@ -115,7 +131,7 @@
         <span class="standard-autumn-time-separator">:</span>
         <select
           bind:value={newStepMinute}
-          on:change={() => (startUserChanged = true)}
+          onchange={() => (startUserChanged = true)}
           class="standard-autumn-select-time"
           required
         >
@@ -138,7 +154,7 @@
           bind:value={newStepEndHour}
           class="standard-autumn-select-time"
           required
-          on:change={() => (endUserChanged = true)}
+          onchange={() => (endUserChanged = true)}
         >
           {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
             <option value={hour}>{hour}</option>
@@ -149,7 +165,7 @@
           bind:value={newStepEndMinute}
           class="standard-autumn-select-time"
           required
-          on:change={() => (endUserChanged = true)}
+          onchange={() => (endUserChanged = true)}
         >
           <option value="00">00</option>
           <option value="15">15</option>

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/AddStepForm.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/AddStepForm.svelte
@@ -34,14 +34,51 @@
     onCancel,
   }: Props = $props();
 
+  // End time state for the form (allow specifying end time when creating)
+  let newStepEndDate = $state(newStep.date || "");
+  let newStepEndHour = $state(String((parseInt(newStepHour || "09", 10) + 1) % 24).padStart(2, "0"));
+  let newStepEndMinute = $state(newStepMinute || "00");
+  let startUserChanged = $state(false);
+  let endUserChanged = $state(false);
+  const DEFAULT_DURATION_MIN = 60;
+
   $effect(() => {
     newStep.time = `${newStepHour}:${newStepMinute}`;
   });
 
+  $effect(() => {
+    // keep end date defaulted to the start date unless user changes it
+    if (!newStepEndDate) newStepEndDate = newStep.date;
+    if (endUserChanged) return;
+    // compute default end from start
+    if (!newStep.date || !newStepHour || !newStepMinute) return;
+    try {
+      const startAt = createTimestamp(newStep.date, `${newStepHour}:${newStepMinute}`);
+      const endAt = createEndTimestamp(startAt, DEFAULT_DURATION_MIN);
+      const d = new Date(endAt);
+      newStepEndDate = d.toISOString().split("T")[0];
+      newStepEndHour = String(d.getHours()).padStart(2, "0");
+      newStepEndMinute = String(d.getMinutes()).padStart(2, "0");
+    } catch (e) {
+      // ignore
+    }
+  });
+
   function handleSubmit(e: Event) {
     e.preventDefault();
-    const startAt = createTimestamp(newStep.date, newStep.time);
-    const endAt = createEndTimestamp(startAt);
+    if (!newStep.title.trim() || !newStep.date || !newStepHour || !newStepMinute) {
+      alert("タイトル、日付、時刻は必須です");
+      return;
+    }
+
+    const startAt = createTimestamp(newStep.date, `${newStepHour}:${newStepMinute}`);
+    const endAt = createTimestamp(newStepEndDate || newStep.date, `${newStepEndHour}:${newStepEndMinute}`);
+
+    if (endAt <= startAt) {
+      alert("終了時刻は開始時刻より後にしてください");
+      return;
+    }
+
     onSubmit({ start_at: startAt, end_at: endAt, type: newStep.type });
   }
 </script>
@@ -60,12 +97,14 @@
       <input
         type="date"
         bind:value={newStep.date}
+        on:change={() => (startUserChanged = true)}
         class="standard-autumn-input"
         required
       />
       <div class="standard-autumn-time-picker">
         <select
           bind:value={newStepHour}
+          on:change={() => (startUserChanged = true)}
           class="standard-autumn-select-time"
           required
         >
@@ -76,8 +115,41 @@
         <span class="standard-autumn-time-separator">:</span>
         <select
           bind:value={newStepMinute}
+          on:change={() => (startUserChanged = true)}
           class="standard-autumn-select-time"
           required
+        >
+          <option value="00">00</option>
+          <option value="15">15</option>
+          <option value="30">30</option>
+          <option value="45">45</option>
+        </select>
+      </div>
+    </div>
+    <div class="standard-autumn-datetime">
+      <label class="standard-autumn-form-label">終了日時</label>
+      <input
+        type="date"
+        bind:value={newStepEndDate}
+        class="standard-autumn-input"
+      />
+      <div class="standard-autumn-time-picker">
+        <select
+          bind:value={newStepEndHour}
+          class="standard-autumn-select-time"
+          required
+          on:change={() => (endUserChanged = true)}
+        >
+          {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
+            <option value={hour}>{hour}</option>
+          {/each}
+        </select>
+        <span class="standard-autumn-time-separator">:</span>
+        <select
+          bind:value={newStepEndMinute}
+          class="standard-autumn-select-time"
+          required
+          on:change={() => (endUserChanged = true)}
         >
           <option value="00">00</option>
           <option value="15">15</option>

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
@@ -105,7 +105,10 @@
     editEndMinute = endMinute;
     startUserChanged = false;
     endUserChanged = false;
-    originalDuration = Math.max(1, Math.round((step.end_at - step.start_at) / 60000));
+    originalDuration = Math.max(
+      1,
+      Math.round((step.end_at - step.start_at) / 60000),
+    );
   }
 
   function cancelEdit() {
@@ -173,8 +176,14 @@
 
     const noteText = (editedStep.notes ?? "").trim();
     const notes = updateMemoText(step.notes, noteText);
-    const startAt = createTimestamp(editedStep.startDate, `${editStartHour}:${editStartMinute}`);
-    const endAt = createTimestamp(editedStep.endDate, `${editEndHour}:${editEndMinute}`);
+    const startAt = createTimestamp(
+      editedStep.startDate,
+      `${editStartHour}:${editStartMinute}`,
+    );
+    const endAt = createTimestamp(
+      editedStep.endDate,
+      `${editEndHour}:${editEndMinute}`,
+    );
 
     if (endAt <= startAt) {
       alert("終了時刻は開始時刻より後にしてください");
@@ -283,7 +292,7 @@
                   id="start-date-input"
                   type="date"
                   bind:value={editedStep.startDate}
-                  on:change={() => (startUserChanged = true)}
+                  onchange={() => (startUserChanged = true)}
                   class="standard-autumn-input"
                 />
               </div>
@@ -292,7 +301,7 @@
                   bind:value={editStartHour}
                   class="standard-autumn-select-time"
                   title="時間を選択"
-                  on:change={() => (startUserChanged = true)}
+                  onchange={() => (startUserChanged = true)}
                 >
                   {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
                     <option value={hour}>{hour}</option>
@@ -303,7 +312,7 @@
                   bind:value={editStartMinute}
                   class="standard-autumn-select-time"
                   title="分を選択"
-                  on:change={() => (startUserChanged = true)}
+                  onchange={() => (startUserChanged = true)}
                 >
                   <option value="00">00</option>
                   <option value="15">15</option>
@@ -323,7 +332,7 @@
                   id="end-date-input"
                   type="date"
                   bind:value={editedStep.endDate}
-                  on:change={() => (endUserChanged = true)}
+                  onchange={() => (endUserChanged = true)}
                   class="standard-autumn-input"
                 />
               </div>
@@ -332,7 +341,7 @@
                   bind:value={editEndHour}
                   class="standard-autumn-select-time"
                   title="時間を選択"
-                  on:change={() => (endUserChanged = true)}
+                  onchange={() => (endUserChanged = true)}
                 >
                   {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
                     <option value={hour}>{hour}</option>
@@ -343,7 +352,7 @@
                   bind:value={editEndMinute}
                   class="standard-autumn-select-time"
                   title="分を選択"
-                  on:change={() => (endUserChanged = true)}
+                  onchange={() => (endUserChanged = true)}
                 >
                   <option value="00">00</option>
                   <option value="15">15</option>

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
@@ -68,6 +68,9 @@
   let editStartMinute = $state(getStepTime(step).split(":")[1]);
   let editEndHour = $state("10");
   let editEndMinute = $state("00");
+  let startUserChanged = $state(false);
+  let endUserChanged = $state(false);
+  let originalDuration = $state(60);
 
   function formatTime(ms: number): [string, string] {
     const date = new Date(ms);
@@ -100,6 +103,9 @@
     editStartMinute = startMinute;
     editEndHour = endHour;
     editEndMinute = endMinute;
+    startUserChanged = false;
+    endUserChanged = false;
+    originalDuration = Math.max(1, Math.round((step.end_at - step.start_at) / 60000));
   }
 
   function cancelEdit() {
@@ -110,15 +116,55 @@
     editStartMinute = startMinute;
     editEndHour = "10";
     editEndMinute = "00";
+    startUserChanged = false;
+    endUserChanged = false;
   }
+
+  $effect(() => {
+    // when start changes and end hasn't been edited by the user,
+    // auto shift end to maintain original duration
+    if (!isEditing) return;
+    if (!editedStep.startDate) return;
+    if (endUserChanged) return;
+    const startTime = `${editStartHour}:${editStartMinute}`;
+    const startAt = createTimestamp(editedStep.startDate, startTime);
+    const newEndAt = createEndTimestamp(startAt, originalDuration);
+    const d = new Date(newEndAt);
+    const eh = String(d.getHours()).padStart(2, "0");
+    const em = String(d.getMinutes()).padStart(2, "0");
+    editEndHour = eh;
+    editEndMinute = em;
+    editedStep.endDate = d.toISOString().split("T")[0];
+    editedStep.endTime = `${eh}:${em}`;
+  });
+
+  $effect(() => {
+    // when end changes and start hasn't been edited by the user,
+    // shift start to preserve duration (or keep 1h default)
+    if (!isEditing) return;
+    if (!editedStep.endDate) return;
+    if (startUserChanged) return;
+    const endTime = `${editEndHour}:${editEndMinute}`;
+    const endAt = createTimestamp(editedStep.endDate, endTime);
+    const newStartAt = endAt - Math.max(1, originalDuration) * 60 * 1000;
+    const d = new Date(newStartAt);
+    const sh = String(d.getHours()).padStart(2, "0");
+    const sm = String(d.getMinutes()).padStart(2, "0");
+    editStartHour = sh;
+    editStartMinute = sm;
+    editedStep.startDate = d.toISOString().split("T")[0];
+    editedStep.startTime = `${sh}:${sm}`;
+  });
 
   async function handleUpdate() {
     if (
       !editedStep.title?.trim() ||
       !editedStep.startDate ||
-      !editedStep.startTime ||
+      !editStartHour ||
+      !editStartMinute ||
       !editedStep.endDate ||
-      !editedStep.endTime ||
+      !editEndHour ||
+      !editEndMinute ||
       !onUpdateStep
     ) {
       alert("タイトル、日付、開始時刻、終了時刻は必須です");
@@ -127,8 +173,13 @@
 
     const noteText = (editedStep.notes ?? "").trim();
     const notes = updateMemoText(step.notes, noteText);
-    const startAt = createTimestamp(editedStep.startDate, editedStep.startTime);
-    const endAt = createTimestamp(editedStep.endDate, editedStep.endTime);
+    const startAt = createTimestamp(editedStep.startDate, `${editStartHour}:${editStartMinute}`);
+    const endAt = createTimestamp(editedStep.endDate, `${editEndHour}:${editEndMinute}`);
+
+    if (endAt <= startAt) {
+      alert("終了時刻は開始時刻より後にしてください");
+      return;
+    }
 
     await onUpdateStep(step.id, {
       title: editedStep.title.trim(),
@@ -232,6 +283,7 @@
                   id="start-date-input"
                   type="date"
                   bind:value={editedStep.startDate}
+                  on:change={() => (startUserChanged = true)}
                   class="standard-autumn-input"
                 />
               </div>
@@ -240,6 +292,7 @@
                   bind:value={editStartHour}
                   class="standard-autumn-select-time"
                   title="時間を選択"
+                  on:change={() => (startUserChanged = true)}
                 >
                   {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
                     <option value={hour}>{hour}</option>
@@ -250,6 +303,7 @@
                   bind:value={editStartMinute}
                   class="standard-autumn-select-time"
                   title="分を選択"
+                  on:change={() => (startUserChanged = true)}
                 >
                   <option value="00">00</option>
                   <option value="15">15</option>
@@ -269,6 +323,7 @@
                   id="end-date-input"
                   type="date"
                   bind:value={editedStep.endDate}
+                  on:change={() => (endUserChanged = true)}
                   class="standard-autumn-input"
                 />
               </div>
@@ -277,6 +332,7 @@
                   bind:value={editEndHour}
                   class="standard-autumn-select-time"
                   title="時間を選択"
+                  on:change={() => (endUserChanged = true)}
                 >
                   {#each Array.from( { length: 24 }, (_, i) => String(i).padStart(2, "0"), ) as hour}
                     <option value={hour}>{hour}</option>
@@ -287,6 +343,7 @@
                   bind:value={editEndMinute}
                   class="standard-autumn-select-time"
                   title="分を選択"
+                  on:change={() => (endUserChanged = true)}
                 >
                   <option value="00">00</option>
                   <option value="15">15</option>

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/EventDetailDialog.svelte
@@ -125,38 +125,58 @@
 
   $effect(() => {
     // when start changes and end hasn't been edited by the user,
-    // auto shift end to maintain original duration
+    // only auto-adjust end if the start would move past the current end
     if (!isEditing) return;
     if (!editedStep.startDate) return;
     if (endUserChanged) return;
-    const startTime = `${editStartHour}:${editStartMinute}`;
-    const startAt = createTimestamp(editedStep.startDate, startTime);
-    const newEndAt = createEndTimestamp(startAt, originalDuration);
-    const d = new Date(newEndAt);
-    const eh = String(d.getHours()).padStart(2, "0");
-    const em = String(d.getMinutes()).padStart(2, "0");
-    editEndHour = eh;
-    editEndMinute = em;
-    editedStep.endDate = d.toISOString().split("T")[0];
-    editedStep.endTime = `${eh}:${em}`;
+    try {
+      const startTime = `${editStartHour}:${editStartMinute}`;
+      const startAt = createTimestamp(editedStep.startDate, startTime);
+      const currentEndAt = createTimestamp(
+        editedStep.endDate || editedStep.startDate,
+        `${editEndHour}:${editEndMinute}`,
+      );
+      if (startAt >= currentEndAt) {
+        const newEndAt = createEndTimestamp(startAt, originalDuration);
+        const d = new Date(newEndAt);
+        const eh = String(d.getHours()).padStart(2, "0");
+        const em = String(d.getMinutes()).padStart(2, "0");
+        editEndHour = eh;
+        editEndMinute = em;
+        editedStep.endDate = d.toISOString().split("T")[0];
+        editedStep.endTime = `${eh}:${em}`;
+      }
+    } catch (e) {
+      // ignore parse errors
+    }
   });
 
   $effect(() => {
     // when end changes and start hasn't been edited by the user,
-    // shift start to preserve duration (or keep 1h default)
+    // only auto-adjust start if the end would move before the current start
     if (!isEditing) return;
     if (!editedStep.endDate) return;
     if (startUserChanged) return;
-    const endTime = `${editEndHour}:${editEndMinute}`;
-    const endAt = createTimestamp(editedStep.endDate, endTime);
-    const newStartAt = endAt - Math.max(1, originalDuration) * 60 * 1000;
-    const d = new Date(newStartAt);
-    const sh = String(d.getHours()).padStart(2, "0");
-    const sm = String(d.getMinutes()).padStart(2, "0");
-    editStartHour = sh;
-    editStartMinute = sm;
-    editedStep.startDate = d.toISOString().split("T")[0];
-    editedStep.startTime = `${sh}:${sm}`;
+    try {
+      const endTime = `${editEndHour}:${editEndMinute}`;
+      const endAt = createTimestamp(editedStep.endDate, endTime);
+      const currentStartAt = createTimestamp(
+        editedStep.startDate || editedStep.endDate,
+        `${editStartHour}:${editStartMinute}`,
+      );
+      if (endAt <= currentStartAt) {
+        const newStartAt = endAt - Math.max(1, originalDuration) * 60 * 1000;
+        const d = new Date(newStartAt);
+        const sh = String(d.getHours()).padStart(2, "0");
+        const sm = String(d.getMinutes()).padStart(2, "0");
+        editStartHour = sh;
+        editStartMinute = sm;
+        editedStep.startDate = d.toISOString().split("T")[0];
+        editedStep.startTime = `${sh}:${sm}`;
+      }
+    } catch (e) {
+      // ignore parse errors
+    }
   });
 
   async function handleUpdate() {

--- a/apps/web/src/lib/themes/standard-seasons/shared/components/SettingsDialog.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/components/SettingsDialog.svelte
@@ -74,8 +74,9 @@
       >
         {@html PaletteIcon}
         <h3>テーマ</h3>
-        <span class="standard-autumn-collapse-icon" class:expanded={showThemeList}
-          >▼</span
+        <span
+          class="standard-autumn-collapse-icon"
+          class:expanded={showThemeList}>▼</span
         >
       </div>
       <p class="standard-autumn-settings-page-description">
@@ -132,10 +133,14 @@
 
       {#if localSecretEnabled}
         <div class="standard-autumn-settings-page-field">
-          <label class="standard-autumn-settings-page-label">
+          <label
+            for="secret-offset-select"
+            class="standard-autumn-settings-page-label"
+          >
             予定の表示開始時刻
           </label>
           <select
+            id="secret-offset-select"
             bind:value={localSecretOffset}
             class="standard-autumn-settings-page-select"
           >
@@ -174,10 +179,14 @@
         Walicaの割り勘グループと連携できます
       </p>
       <div class="standard-autumn-settings-page-field">
-        <label class="standard-autumn-settings-page-label">
+        <label
+          for="walica-url-input"
+          class="standard-autumn-settings-page-label"
+        >
           Walica グループURL
         </label>
         <input
+          id="walica-url-input"
           type="text"
           bind:value={localWalicaUrl}
           placeholder="https://walica.jp/group/..."

--- a/apps/web/src/lib/themes/standard-seasons/shared/styles/timeline.css
+++ b/apps/web/src/lib/themes/standard-seasons/shared/styles/timeline.css
@@ -88,7 +88,7 @@
 
 /* Transport (移動) style — visual movement feeling */
 .standard-autumn-step-content.standard-autumn-step-transport {
-  background: linear-gradient(90deg, rgba(13,110,253,0.06), rgba(56,189,248,0.04));
+  background: linear-gradient(90deg, rgba(13, 110, 253, 0.06), rgba(56, 189, 248, 0.04));
   border-left-style: dashed;
   border-left-color: var(--standard-autumn-primary);
   color: var(--standard-autumn-text);
@@ -119,7 +119,7 @@
 .moving-trail {
   width: 60px;
   height: 4px;
-  background: linear-gradient(90deg, rgba(13,110,253,0.2), rgba(13,110,253,0));
+  background: linear-gradient(90deg, rgba(13, 110, 253, 0.2), rgba(13, 110, 253, 0));
   border-radius: 4px;
   opacity: 0.8;
   transform-origin: left center;
@@ -127,15 +127,37 @@
 }
 
 @keyframes vehicle-move {
-  0% { transform: translateX(-6px); opacity: 0.6; }
-  50% { transform: translateX(6px); opacity: 1; }
-  100% { transform: translateX(-6px); opacity: 0.6; }
+  0% {
+    transform: translateX(-6px);
+    opacity: 0.6;
+  }
+
+  50% {
+    transform: translateX(6px);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateX(-6px);
+    opacity: 0.6;
+  }
 }
 
 @keyframes trail-flow {
-  0% { transform: scaleX(0.2); opacity: 0.4; }
-  50% { transform: scaleX(1); opacity: 0.9; }
-  100% { transform: scaleX(0.2); opacity: 0.4; }
+  0% {
+    transform: scaleX(0.2);
+    opacity: 0.4;
+  }
+
+  50% {
+    transform: scaleX(1);
+    opacity: 0.9;
+  }
+
+  100% {
+    transform: scaleX(0.2);
+    opacity: 0.4;
+  }
 }
 
 .standard-autumn-step-location {

--- a/apps/web/src/lib/themes/standard-seasons/shared/styles/timeline.css
+++ b/apps/web/src/lib/themes/standard-seasons/shared/styles/timeline.css
@@ -86,6 +86,58 @@
   position: relative;
 }
 
+/* Transport (移動) style — visual movement feeling */
+.standard-autumn-step-content.standard-autumn-step-transport {
+  background: linear-gradient(90deg, rgba(13,110,253,0.06), rgba(56,189,248,0.04));
+  border-left-style: dashed;
+  border-left-color: var(--standard-autumn-primary);
+  color: var(--standard-autumn-text);
+  overflow: visible;
+}
+
+.standard-autumn-transport-overlay {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.moving-vehicle {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--standard-autumn-primary);
+  animation: vehicle-move 1.4s linear infinite;
+}
+
+.moving-trail {
+  width: 60px;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(13,110,253,0.2), rgba(13,110,253,0));
+  border-radius: 4px;
+  opacity: 0.8;
+  transform-origin: left center;
+  animation: trail-flow 1.4s linear infinite;
+}
+
+@keyframes vehicle-move {
+  0% { transform: translateX(-6px); opacity: 0.6; }
+  50% { transform: translateX(6px); opacity: 1; }
+  100% { transform: translateX(-6px); opacity: 0.6; }
+}
+
+@keyframes trail-flow {
+  0% { transform: scaleX(0.2); opacity: 0.4; }
+  50% { transform: scaleX(1); opacity: 0.9; }
+  100% { transform: scaleX(0.2); opacity: 0.4; }
+}
+
 .standard-autumn-step-location {
   font-size: 0.85rem;
   color: var(--standard-autumn-text-light);

--- a/apps/web/src/lib/themes/standard-seasons/shared/styles/variables.css
+++ b/apps/web/src/lib/themes/standard-seasons/shared/styles/variables.css
@@ -62,3 +62,23 @@
   --standard-winter-shadow: 0 12px 36px -8px rgba(30, 58, 138, 0.15);
   --standard-winter-shadow-sm: 0 4px 12px -2px rgba(30, 58, 138, 0.1);
 }
+
+/* Semantic aliases for the active theme (default: autumn).
+   These provide a stable set of variables to use when implementing
+   theme-agnostic components or future refactors. */
+:root {
+  --theme-bg: var(--standard-autumn-bg);
+  --theme-primary: var(--standard-autumn-primary);
+  --theme-primary-light: var(--standard-autumn-primary-light);
+  --theme-secondary: var(--standard-autumn-secondary);
+  --theme-accent: var(--standard-autumn-accent);
+  --theme-text: var(--standard-autumn-text);
+  --theme-text-light: var(--standard-autumn-text-light);
+  --theme-card-bg: var(--standard-autumn-card-bg);
+  --theme-header-bg: var(--standard-autumn-header-bg);
+  --theme-border: var(--standard-autumn-border);
+  --theme-line-color: var(--standard-autumn-line-color);
+  --theme-dot-bg: var(--standard-autumn-dot-bg);
+  --theme-shadow: var(--standard-autumn-shadow);
+  --theme-shadow-sm: var(--standard-autumn-shadow-sm);
+}

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.spec.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Step } from '@tabitabi/types';
-import { getOverlappingStepsForDay, getEventStyleForDay, DEFAULT_HOURS } from './weekview-utils';
+import { getOverlappingStepsForDay, getEventStyleForDay, getWeekHours, DEFAULT_HOURS } from './weekview-utils';
 
 describe('WeekView utils', () => {
   it('computes a single positioned event for a 9:00-11:30 step', () => {
@@ -27,5 +27,25 @@ describe('WeekView utils', () => {
     const style = getEventStyleForDay(DEFAULT_HOURS, p.relStart, p.relEnd, p.index, p.totalCount);
     expect(style).toMatch(/top:\s*\d+px/);
     expect(style).toMatch(/height:\s*\d+px/);
+  });
+
+  it('extends visible hours to 23:00 when a step exists after 21:00', () => {
+    const step: Step = {
+      id: 's-late',
+      itinerary_id: 'it1',
+      title: 'Late Event',
+      start_at: new Date(2024, 0, 1, 21, 30).getTime(),
+      end_at: new Date(2024, 0, 1, 22, 15).getTime(),
+      location: null,
+      notes: '',
+      type: 'normal:general',
+      is_hidden: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const hours = getWeekHours([step]);
+    expect(hours[0]).toBe(6);
+    expect(hours[hours.length - 1]).toBe(23);
   });
 });

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.spec.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import type { Step } from '@tabitabi/types';
+import { getOverlappingStepsForDay, getEventStyleForDay, DEFAULT_HOURS } from './weekview-utils';
+
+describe('WeekView utils', () => {
+  it('computes a single positioned event for a 9:00-11:30 step', () => {
+    const date = '2024-01-01';
+    const startAt = new Date(`${date}T09:00:00`).getTime();
+    const endAt = new Date(`${date}T11:30:00`).getTime();
+    const step: Step = {
+      id: 's1',
+      itinerary_id: 'it1',
+      title: 'Test',
+      start_at: startAt,
+      end_at: endAt,
+      location: null,
+      notes: '',
+      type: 'normal:general',
+      is_hidden: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const positioned = getOverlappingStepsForDay([step], date);
+    expect(positioned.length).toBe(1);
+    const p = positioned[0];
+    const style = getEventStyleForDay(DEFAULT_HOURS, p.relStart, p.relEnd, p.index, p.totalCount);
+    expect(style).toMatch(/top:\s*\d+px/);
+    expect(style).toMatch(/height:\s*\d+px/);
+  });
+});

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -217,7 +217,7 @@
   }
 
   .standard-autumn-week-corner::before {
-    content: '';
+    content: "";
     position: absolute;
     bottom: 0;
     left: 0;
@@ -242,7 +242,7 @@
   }
 
   .standard-autumn-week-day-header::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
@@ -254,20 +254,19 @@
   }
 
   .standard-autumn-week-day-header::after {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: 
-      repeating-linear-gradient(
-        -45deg,
-        transparent,
-        transparent 10px,
-        rgba(var(--standard-autumn-primary-rgb), 0.03) 10px,
-        rgba(var(--standard-autumn-primary-rgb), 0.03) 11px
-      );
+    background: repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 10px,
+      rgba(var(--standard-autumn-primary-rgb), 0.03) 10px,
+      rgba(var(--standard-autumn-primary-rgb), 0.03) 11px
+    );
     pointer-events: none;
   }
 
@@ -336,7 +335,7 @@
   }
 
   .standard-autumn-week-time-label::before {
-    content: '';
+    content: "";
     position: absolute;
     right: 0;
     top: 50%;
@@ -347,7 +346,7 @@
   }
 
   .standard-autumn-week-time-label::after {
-    content: '';
+    content: "";
     position: absolute;
     left: 0;
     right: 0;
@@ -369,20 +368,19 @@
   }
 
   .standard-autumn-week-cell::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
-    background: 
-      repeating-linear-gradient(
-        90deg,
-        transparent,
-        transparent 20px,
-        rgba(var(--standard-autumn-primary-rgb), 0.01) 20px,
-        rgba(var(--standard-autumn-primary-rgb), 0.01) 21px
-      );
+    background: repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 20px,
+      rgba(var(--standard-autumn-primary-rgb), 0.01) 20px,
+      rgba(var(--standard-autumn-primary-rgb), 0.01) 21px
+    );
     pointer-events: none;
   }
 
@@ -409,7 +407,7 @@
     z-index: 10;
     cursor: pointer;
     transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 
+    box-shadow:
       0 2px 6px rgba(0, 0, 0, 0.12),
       inset 0 1px 2px rgba(255, 255, 255, 0.15);
     margin: 2px;
@@ -418,7 +416,7 @@
   }
 
   .standard-autumn-week-event::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 2px;
     left: 2px;
@@ -429,7 +427,7 @@
   }
 
   .standard-autumn-week-event::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: 2px;
     left: 50%;
@@ -443,14 +441,14 @@
   .standard-autumn-week-event:hover {
     z-index: 20;
     transform: translateY(-4px) scale(1.06);
-    box-shadow: 
+    box-shadow:
       0 8px 16px rgba(0, 0, 0, 0.18),
       inset 0 1px 2px rgba(255, 255, 255, 0.25);
   }
 
   .standard-autumn-week-event:active {
     transform: translateY(-1px) scale(0.98);
-    box-shadow: 
+    box-shadow:
       0 2px 4px rgba(0, 0, 0, 0.12),
       inset 0 1px 2px rgba(255, 255, 255, 0.15);
   }
@@ -460,7 +458,7 @@
     border-color: var(--standard-autumn-accent);
     border-left: 4px solid rgba(255, 255, 255, 0.6);
     padding-left: 6px;
-    box-shadow: 
+    box-shadow:
       0 2px 6px rgba(0, 0, 0, 0.15),
       inset 0 0 8px rgba(255, 255, 255, 0.1);
   }
@@ -471,7 +469,7 @@
   }
 
   .standard-autumn-week-event-transport::after {
-    content: '→';
+    content: "→";
     position: absolute !important;
     right: 4px;
     top: 50%;
@@ -485,7 +483,8 @@
   }
 
   @keyframes shimmer-top {
-    0%, 100% {
+    0%,
+    100% {
       opacity: 0.6;
     }
     50% {
@@ -494,7 +493,8 @@
   }
 
   @keyframes pulse-arrow {
-    0%, 100% {
+    0%,
+    100% {
       transform: translateY(-50%) translateX(0);
       opacity: 0.9;
     }

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -38,23 +38,23 @@
   }
 
   function getWeekDates(): Date[] {
-    const dates: string[] = [];
-    for (const step of steps) {
-      const date = getStepDate(step);
-      if (!dates.includes(date)) {
-        dates.push(date);
-      }
+    if (steps.length === 0) return [];
+
+    let minDay = Infinity;
+    let maxDay = -Infinity;
+
+    for (const s of steps) {
+      const sd = new Date(s.start_at);
+      sd.setHours(0, 0, 0, 0);
+      const ed = new Date(s.end_at);
+      ed.setHours(0, 0, 0, 0);
+      minDay = Math.min(minDay, sd.getTime());
+      maxDay = Math.max(maxDay, ed.getTime());
     }
-    dates.sort();
-
-    if (dates.length === 0) return [];
-
-    const startDate = new Date(dates[0]);
-    const endDate = new Date(dates[dates.length - 1]);
 
     const weekDates: Date[] = [];
-    const current = new Date(startDate);
-    while (current <= endDate) {
+    const current = new Date(minDay);
+    while (current.getTime() <= maxDay) {
       weekDates.push(new Date(current));
       current.setDate(current.getDate() + 1);
     }
@@ -95,26 +95,44 @@
   function getOverlappingStepsForDay(
     dateStr: string,
   ): Array<{ step: Step; index: number; totalCount: number }> {
-    const daySteps = stepsByDate().get(dateStr) || [];
-    const sortedSteps = [...daySteps].sort((a, b) => a.start_at - b.start_at);
+    const DAY_START = new Date(`${dateStr}T00:00:00`).getTime();
+    const DAY_END = DAY_START + 24 * 60 * 60 * 1000;
 
-    const positioned: { step: Step; index: number; totalCount: number }[] = [];
+    const daySteps = steps.filter(
+      (s) => s.start_at < DAY_END && s.end_at > DAY_START,
+    );
 
-    for (const step of sortedSteps) {
-      const conflicting = sortedSteps.filter(
-        (s) =>
-          s !== step && s.start_at < step.end_at && s.end_at > step.start_at,
+    const enriched = daySteps.map((s) => {
+      const relStart = Math.max(
+        0,
+        Math.floor((Math.max(s.start_at, DAY_START) - DAY_START) / 60000),
+      );
+      const relEnd = Math.min(
+        24 * 60,
+        Math.ceil((Math.min(s.end_at, DAY_END) - DAY_START) / 60000),
+      );
+      return { step: s, relStart, relEnd };
+    });
+
+    enriched.sort((a, b) => a.relStart - b.relStart || a.relEnd - b.relEnd);
+
+    const positioned: { step: Step; index: number; totalCount: number; relStart: number; relEnd: number }[] = [];
+
+    for (const item of enriched) {
+      const conflicting = enriched.filter(
+        (o) =>
+          o.step !== item.step && !(o.relEnd <= item.relStart || o.relStart >= item.relEnd),
       );
 
-      const assignedIndex = conflicting.filter(
-        (s) => s.start_at < step.start_at,
-      ).length;
-      const maxOverlapCount = conflicting.length + 1;
+      const assignedIndex = conflicting.filter((o) => o.relStart < item.relStart).length;
+      const maxOverlapCount = Math.max(1, conflicting.length + 1);
 
       positioned.push({
-        step,
+        step: item.step,
         index: assignedIndex,
         totalCount: maxOverlapCount,
+        relStart: item.relStart,
+        relEnd: item.relEnd,
       });
     }
 
@@ -127,16 +145,16 @@
   ): Array<{ step: Step; index: number; totalCount: number }> {
     const hourStart = hour * 60;
     const hourEnd = (hour + 1) * 60;
-    const dayPositions = getOverlappingStepsForDay(dateStr);
+    const dayPositions = getOverlappingStepsForDay(dateStr) as Array<{
+      step: Step;
+      index: number;
+      totalCount: number;
+      relStart: number;
+      relEnd: number;
+    }>;
 
-    return dayPositions.filter(({ step }) => {
-      const startTime = new Date(step.start_at);
-      const endTime = new Date(step.end_at);
-      const stepStartMinutes =
-        startTime.getHours() * 60 + startTime.getMinutes();
-      const stepEndMinutes = endTime.getHours() * 60 + endTime.getMinutes();
-
-      return stepStartMinutes >= hourStart && stepStartMinutes < hourEnd;
+    return dayPositions.filter(({ relStart, relEnd }) => {
+      return relStart < hourEnd && relEnd > hourStart;
     });
   }
 
@@ -144,15 +162,11 @@
     step: Step,
     index: number,
     totalCount: number,
+    relStart: number,
+    relEnd: number,
   ): string {
-    const startTs = new Date(step.start_at);
-    const endTs = new Date(step.end_at);
-
-    const topOffset = (startTs.getMinutes() / 60) * 40;
-    const durationMinutes = Math.max(
-      15,
-      Math.round((endTs.getTime() - startTs.getTime()) / 60000),
-    );
+    const topOffset = ((relStart % 60) / 60) * 40;
+    const durationMinutes = Math.max(15, relEnd - relStart);
     const height = Math.max((durationMinutes / 60) * 40, 38);
     const width = 100 / totalCount;
     const left = index * width;
@@ -187,7 +201,7 @@
         {#each weekDates as date}
           <div
             class="standard-autumn-week-day-header"
-            class:has-events={stepsByDate().has(formatDateKey(date))}
+            class:has-events={getOverlappingStepsForDay(formatDateKey(date)).length > 0}
           >
             <div class="standard-autumn-week-day-name">{getDayName(date)}</div>
             <div class="standard-autumn-week-day-date">
@@ -204,12 +218,12 @@
           </div>
           {#each weekDates as date}
             <div class="standard-autumn-week-cell">
-              {#each getEventsForCell(formatDateKey(date), hour) as { step, index, totalCount }}
+              {#each getEventsForCell(formatDateKey(date), hour) as { step, index, totalCount, relStart, relEnd }}
                 {#if isSecretStep(step) && !hasEditPermission}
                   <button
                     type="button"
                     class="standard-autumn-week-event"
-                    style={getEventStyle(step, index, totalCount)}
+                    style={getEventStyle(step, index, totalCount, relStart, relEnd)}
                     title="Secret"
                     onclick={() => handleEventClick(step)}
                   >
@@ -222,7 +236,7 @@
                     class:standard-autumn-week-event-transport={isTransportType(
                       step.type,
                     )}
-                    style={getEventStyle(step, index, totalCount)}
+                    style={getEventStyle(step, index, totalCount, relStart, relEnd)}
                     title={step.title}
                     onclick={() => handleEventClick(step)}
                   >

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Step } from "@tabitabi/types";
-  import { getStepDate, getStepTime, getStepEndTime } from "@tabitabi/types";
+  import { getStepDate } from "@tabitabi/types";
   import EventDetailDialog from "../components/EventDetailDialog.svelte";
   import IconRenderer from "../icons/IconRenderer.svelte";
   import { isTransportType } from "../utils/step-type";
@@ -43,8 +43,6 @@
     return now < revealTime;
   }
 
-  // Week/date helpers moved to utils
-
   function formatDateKey(date: Date): string {
     const y = date.getFullYear();
     const m = String(date.getMonth() + 1).padStart(2, "0");
@@ -61,21 +59,8 @@
     return `${date.getMonth() + 1}/${date.getDate()}`;
   }
 
-  const stepsByDate = $derived(() => {
-    const map = new Map<string, Step[]>();
-    for (const step of steps) {
-      const date = getStepDate(step);
-      if (!map.has(date)) map.set(date, []);
-      map.get(date)!.push(step);
-    }
-    return map;
-  });
-
   const weekDates = $derived(() => getWeekDatesFromSteps(steps));
-
   const hours = DEFAULT_HOURS;
-
-  // helpers moved to weekview-utils.ts
 
   function handleEventClick(step: Step) {
     selectedStep = step;
@@ -84,21 +69,20 @@
   function closeDialog() {
     selectedStep = null;
   }
+
+  let numCols = $derived(weekDates().length);
 </script>
 
-<div class="standard-autumn-week-view">
-  {#if weekDates.length === 0}
+<div class="standard-autumn-week-view" style="--week-cols: {numCols};">
+  {#if weekDates().length === 0}
     <div class="standard-autumn-week-no-events">
       予定がまだ登録されていません
     </div>
   {:else}
-    <div
-      class="standard-autumn-week-container"
-      style="grid-template-columns: 60px repeat({weekDates.length}, 1fr);"
-    >
+    <div class="standard-autumn-week-container">
       <div class="standard-autumn-week-header">
         <div class="standard-autumn-week-corner"></div>
-        {#each weekDates as date}
+        {#each weekDates() as date}
           <div
             class="standard-autumn-week-day-header"
             class:has-events={utilGetOverlappingStepsForDay(
@@ -114,72 +98,61 @@
         {/each}
       </div>
 
-      <div
-        class="standard-autumn-week-body"
-        style="grid-template-columns: 60px repeat({weekDates.length}, 1fr);"
-      >
+      <div class="standard-autumn-week-body">
         {#each hours as hour}
           <div class="standard-autumn-week-time-label">
             {String(hour).padStart(2, "0")}:00
           </div>
-        {/each}
-
-        {#each weekDates as date, di}
-          <div
-            class="standard-autumn-week-day-column"
-            style={`grid-column: ${di + 2}; grid-row: 1 / ${hours.length + 1};`}
-          >
-            <div class="standard-autumn-week-day-grid">
-              {#each hours as _}
-                <div class="standard-autumn-week-hour-row"></div>
-              {/each}
+          {#each weekDates() as date}
+            <div class="standard-autumn-week-cell">
+              <div class="standard-autumn-week-cell-background"></div>
+              <div class="standard-autumn-week-cell-content">
+                {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
+                  {#if isSecretStep(step) && !hasEditPermission}
+                    <button
+                      type="button"
+                      class="standard-autumn-week-event"
+                      style={utilGetEventStyleForDay(
+                        hours,
+                        relStart,
+                        relEnd,
+                        index,
+                        totalCount,
+                      )}
+                      title="Secret"
+                      onclick={() => handleEventClick(step)}
+                    >
+                      🔒 Secret
+                    </button>
+                  {:else if relStart < (hour + 1) * 60 && relEnd > hour * 60}
+                    <button
+                      type="button"
+                      class="standard-autumn-week-event"
+                      class:standard-autumn-week-event-transport={isTransportType(
+                        step.type,
+                      )}
+                      style={utilGetEventStyleForDay(
+                        hours,
+                        relStart,
+                        relEnd,
+                        index,
+                        totalCount,
+                      )}
+                      title={step.title}
+                      onclick={() => handleEventClick(step)}
+                    >
+                      <span class="standard-autumn-week-event-icon">
+                        <IconRenderer type={step.type} size="sm" />
+                      </span>
+                      <span class="standard-autumn-week-event-title">
+                        {step.title}
+                      </span>
+                    </button>
+                  {/if}
+                {/each}
+              </div>
             </div>
-            <div class="standard-autumn-week-events">
-              {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
-                {#if isSecretStep(step) && !hasEditPermission}
-                  <button
-                    type="button"
-                    class="standard-autumn-week-event"
-                    style={utilGetEventStyleForDay(
-                      hours,
-                      relStart,
-                      relEnd,
-                      index,
-                      totalCount,
-                    )}
-                    title="Secret"
-                    onclick={() => handleEventClick(step)}
-                  >
-                    🔒 Secret
-                  </button>
-                {:else}
-                  <button
-                    type="button"
-                    class="standard-autumn-week-event"
-                    class:standard-autumn-week-event-transport={isTransportType(
-                      step.type,
-                    )}
-                    style={utilGetEventStyleForDay(
-                      hours,
-                      relStart,
-                      relEnd,
-                      index,
-                      totalCount,
-                    )}
-                    title={step.title}
-                    onclick={() => handleEventClick(step)}
-                  >
-                    <span class="standard-autumn-week-event-icon">
-                      <IconRenderer type={step.type} size="sm" />
-                    </span>
-                    <span class="standard-autumn-week-event-title">
-                      {step.title}
-                    </span>
-                  </button>
-                {/if}
-              {/each}
-            </div>
-          </div>
+          {/each}
         {/each}
       </div>
     </div>
@@ -199,19 +172,159 @@
 {/if}
 
 <style>
-  .standard-autumn-week-body {
-    display: grid;
-    grid-auto-rows: 40px;
-    position: relative;
-    gap: 0;
+  .standard-autumn-week-view {
+    padding: 1rem;
+    padding-bottom: 100px;
+    overflow-x: auto;
+    background: var(--standard-autumn-bg);
   }
 
-  .standard-autumn-week-day-column {
+  .standard-autumn-week-no-events {
+    padding: 2rem;
+    text-align: center;
+    color: var(--standard-autumn-text-light);
+    font-size: 0.95rem;
+  }
+
+  .standard-autumn-week-container {
+    display: grid;
+    grid-template-columns: 70px repeat(var(--week-cols, 7), 1fr);
+    gap: 0;
+    background: var(--standard-autumn-card-bg);
+    border: 3px solid var(--standard-autumn-primary);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  .standard-autumn-week-header {
+    display: contents;
+  }
+
+  .standard-autumn-week-corner {
+    background: var(--standard-autumn-header-bg);
+    border-bottom: 3px solid var(--standard-autumn-primary);
+    border-right: 1px solid var(--standard-autumn-border);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 0.5rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--standard-autumn-text-light);
+    letter-spacing: 0.1em;
     position: relative;
+    overflow: hidden;
+  }
+
+  .standard-autumn-week-corner::before {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--standard-autumn-primary);
+  }
+
+  .standard-autumn-week-day-header {
+    padding: 1.2rem 0.5rem;
+    text-align: center;
+    border-bottom: 3px solid var(--standard-autumn-primary);
+    border-right: 1px solid var(--standard-autumn-border);
+    background: var(--standard-autumn-header-bg);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.35rem;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .standard-autumn-week-day-header::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--standard-autumn-primary);
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .standard-autumn-week-day-header.has-events::before {
+    opacity: 1;
+  }
+
+  .standard-autumn-week-day-header:last-child {
+    border-right: none;
+  }
+
+  .standard-autumn-week-day-name {
+    font-weight: 700;
+    color: var(--standard-autumn-primary);
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .standard-autumn-week-day-date {
+    font-size: 0.85rem;
+    color: var(--standard-autumn-text-light);
+    font-weight: 600;
+  }
+
+  .standard-autumn-week-day-header.has-events .standard-autumn-week-day-date {
+    background: var(--standard-autumn-primary);
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+    font-weight: 700;
+  }
+
+  .standard-autumn-week-body {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: 70px repeat(var(--week-cols, 7), 1fr);
+    grid-auto-rows: 56px;
+    grid-auto-flow: row;
+  }
+
+  .standard-autumn-week-time-label {
+    padding: 0.5rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--standard-autumn-text-light);
+    text-align: right;
+    border-right: 1px solid var(--standard-autumn-border);
+    background: var(--standard-autumn-header-bg);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    letter-spacing: 0.03em;
+  }
+
+  .standard-autumn-week-cell {
+    border-right: 1px solid var(--standard-autumn-border);
+    border-bottom: 1px solid var(--standard-autumn-border);
+    position: relative;
+    background: var(--standard-autumn-bg);
     overflow: visible;
   }
 
-  .standard-autumn-week-day-grid {
+  .standard-autumn-week-cell:nth-child(2n) {
+    background: rgba(var(--standard-autumn-primary-rgb), 0.02);
+  }
+
+  .standard-autumn-week-cell-background {
     position: absolute;
     top: 0;
     left: 0;
@@ -220,18 +333,10 @@
     pointer-events: none;
   }
 
-  .standard-autumn-week-hour-row {
-    height: 40px;
-    border-top: 1px solid var(--standard-autumn-line-color, #eee);
-    box-sizing: border-box;
-  }
-
-  .standard-autumn-week-events {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+  .standard-autumn-week-cell-content {
+    position: relative;
+    width: 100%;
+    height: 100%;
   }
 
   .standard-autumn-week-event {
@@ -239,18 +344,86 @@
     box-sizing: border-box;
     padding: 6px 8px;
     border-radius: 6px;
-    background: var(--standard-autumn-event-bg, #fff);
-    border: 1px solid var(--standard-autumn-border, #e6e0d6);
+    background: var(--standard-autumn-primary);
+    color: #fff;
+    border: 2px solid var(--standard-autumn-primary);
     display: flex;
-    gap: 6px;
+    gap: 4px;
     align-items: center;
     overflow: hidden;
-    text-overflow: ellipsis;
+    font-size: 0.7rem;
+    font-weight: 700;
+    z-index: 10;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    margin: 2px;
     white-space: nowrap;
+  }
+
+  .standard-autumn-week-event::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: rgba(255, 255, 255, 0.5);
+    border-radius: 6px 6px 0 0;
+  }
+
+  .standard-autumn-week-event:hover {
+    z-index: 20;
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .standard-autumn-week-event:active {
+    transform: translateY(0) scale(0.98);
+  }
+
+  .standard-autumn-week-event-transport {
+    background: var(--standard-autumn-accent);
+    border-color: var(--standard-autumn-accent);
+    border-left: 4px solid rgba(255, 255, 255, 0.6);
+  }
+
+  .standard-autumn-week-event-transport::after {
+    content: '⇒';
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.9rem;
+    opacity: 0.8;
+    animation: pulse-arrow 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-arrow {
+    0%, 100% {
+      transform: translateY(-50%) translateX(0);
+      opacity: 0.8;
+    }
+    50% {
+      transform: translateY(-50%) translateX(2px);
+      opacity: 1;
+    }
   }
 
   .standard-autumn-week-event-icon {
     display: inline-flex;
     align-items: center;
+    font-size: 0.95rem;
+    flex-shrink: 0;
+  }
+
+  .standard-autumn-week-event-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+    font-weight: 700;
+    letter-spacing: 0.02em;
   }
 </style>

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -6,9 +6,9 @@
   import { isTransportType } from "../utils/step-type";
   import {
     getWeekDatesFromSteps,
+    getWeekHours,
     getOverlappingStepsForDay as utilGetOverlappingStepsForDay,
     getEventStyleForDay as utilGetEventStyleForDay,
-    DEFAULT_HOURS,
   } from "./weekview-utils";
 
   interface Props {
@@ -60,7 +60,7 @@
   }
 
   const weekDates = $derived(() => getWeekDatesFromSteps(steps));
-  const hours = DEFAULT_HOURS;
+  const hours = $derived(() => getWeekHours(steps));
 
   function handleEventClick(step: Step) {
     selectedStep = step;
@@ -99,60 +99,71 @@
       </div>
 
       <div class="standard-autumn-week-body">
-        {#each hours as hour}
+        {#each hours() as hour}
           <div class="standard-autumn-week-time-label">
             {String(hour).padStart(2, "0")}:00
           </div>
           {#each weekDates() as date}
-            <div class="standard-autumn-week-cell">
-              <div class="standard-autumn-week-cell-content">
-                {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
-                  {#if isSecretStep(step) && !hasEditPermission}
-                    <button
-                      type="button"
-                      class="standard-autumn-week-event"
-                      style={utilGetEventStyleForDay(
-                        hours,
-                        relStart,
-                        relEnd,
-                        index,
-                        totalCount,
-                      )}
-                      title="Secret"
-                      onclick={() => handleEventClick(step)}
-                    >
-                      🔒 Secret
-                    </button>
-                  {:else if relStart < (hour + 1) * 60 && relEnd > hour * 60}
-                    <button
-                      type="button"
-                      class="standard-autumn-week-event"
-                      class:standard-autumn-week-event-transport={isTransportType(
-                        step.type,
-                      )}
-                      style={utilGetEventStyleForDay(
-                        hours,
-                        relStart,
-                        relEnd,
-                        index,
-                        totalCount,
-                      )}
-                      title={step.title}
-                      onclick={() => handleEventClick(step)}
-                    >
-                      <span class="standard-autumn-week-event-icon">
-                        <IconRenderer type={step.type} size="sm" />
-                      </span>
-                      <span class="standard-autumn-week-event-title">
-                        {step.title}
-                      </span>
-                    </button>
-                  {/if}
-                {/each}
-              </div>
-            </div>
+            <div class="standard-autumn-week-cell"></div>
           {/each}
         {/each}
+
+        <div
+          class="standard-autumn-week-events-layer"
+          style="--week-hour-rows: {hours().length};"
+        >
+          {#each weekDates() as date, dayIndex}
+            <div
+              class="standard-autumn-week-day-events"
+              style="grid-column: {dayIndex + 2}; grid-row: 1 / span {hours()
+                .length};"
+            >
+              {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
+                {#if isSecretStep(step) && !hasEditPermission}
+                  <button
+                    type="button"
+                    class="standard-autumn-week-event"
+                    style={utilGetEventStyleForDay(
+                      hours(),
+                      relStart,
+                      relEnd,
+                      index,
+                      totalCount,
+                    )}
+                    title="Secret"
+                    onclick={() => handleEventClick(step)}
+                  >
+                    🔒 Secret
+                  </button>
+                {:else}
+                  <button
+                    type="button"
+                    class="standard-autumn-week-event"
+                    class:standard-autumn-week-event-transport={isTransportType(
+                      step.type,
+                    )}
+                    style={utilGetEventStyleForDay(
+                      hours(),
+                      relStart,
+                      relEnd,
+                      index,
+                      totalCount,
+                    )}
+                    title={step.title}
+                    onclick={() => handleEventClick(step)}
+                  >
+                    <span class="standard-autumn-week-event-icon">
+                      <IconRenderer type={step.type} size="sm" />
+                    </span>
+                    <span class="standard-autumn-week-event-title">
+                      {step.title}
+                    </span>
+                  </button>
+                {/if}
+              {/each}
+            </div>
+          {/each}
+        </div>
       </div>
     </div>
   {/if}
@@ -316,6 +327,7 @@
     grid-auto-rows: 56px;
     grid-auto-flow: row;
     background: var(--standard-autumn-bg);
+    position: relative;
   }
 
   .standard-autumn-week-time-label {
@@ -384,10 +396,20 @@
     pointer-events: none;
   }
 
-  .standard-autumn-week-cell-content {
+  .standard-autumn-week-events-layer {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    grid-template-columns: 70px repeat(var(--week-cols, 7), 1fr);
+    grid-template-rows: repeat(var(--week-hour-rows, 16), 56px);
+    pointer-events: none;
+    z-index: 8;
+  }
+
+  .standard-autumn-week-day-events {
     position: relative;
-    width: 100%;
-    height: 100%;
+    overflow: visible;
+    pointer-events: none;
   }
 
   .standard-autumn-week-event {
@@ -406,6 +428,7 @@
     font-weight: 700;
     z-index: 10;
     cursor: pointer;
+    pointer-events: auto;
     transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
     box-shadow:
       0 2px 6px rgba(0, 0, 0, 0.12),
@@ -454,9 +477,16 @@
   }
 
   .standard-autumn-week-event-transport {
-    background: var(--standard-autumn-accent);
+    background: repeating-linear-gradient(
+        -45deg,
+        rgba(255, 255, 255, 0.1),
+        rgba(255, 255, 255, 0.1) 6px,
+        rgba(255, 255, 255, 0.02) 6px,
+        rgba(255, 255, 255, 0.02) 12px
+      ),
+      var(--standard-autumn-accent);
     border-color: var(--standard-autumn-accent);
-    border-left: 4px solid rgba(255, 255, 255, 0.6);
+    border-left: 4px dashed rgba(255, 255, 255, 0.7);
     padding-left: 6px;
     box-shadow:
       0 2px 6px rgba(0, 0, 0, 0.15),

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -4,6 +4,12 @@
   import EventDetailDialog from "../components/EventDetailDialog.svelte";
   import IconRenderer from "../icons/IconRenderer.svelte";
   import { isTransportType } from "../utils/step-type";
+  import {
+    getWeekDatesFromSteps,
+    getOverlappingStepsForDay as utilGetOverlappingStepsForDay,
+    getEventStyleForDay as utilGetEventStyleForDay,
+    DEFAULT_HOURS,
+  } from "./weekview-utils";
 
   interface Props {
     steps: Step[];
@@ -37,30 +43,7 @@
     return now < revealTime;
   }
 
-  function getWeekDates(): Date[] {
-    if (steps.length === 0) return [];
-
-    let minDay = Infinity;
-    let maxDay = -Infinity;
-
-    for (const s of steps) {
-      const sd = new Date(s.start_at);
-      sd.setHours(0, 0, 0, 0);
-      const ed = new Date(s.end_at);
-      ed.setHours(0, 0, 0, 0);
-      minDay = Math.min(minDay, sd.getTime());
-      maxDay = Math.max(maxDay, ed.getTime());
-    }
-
-    const weekDates: Date[] = [];
-    const current = new Date(minDay);
-    while (current.getTime() <= maxDay) {
-      weekDates.push(new Date(current));
-      current.setDate(current.getDate() + 1);
-    }
-
-    return weekDates;
-  }
+  // Week/date helpers moved to utils
 
   function formatDateKey(date: Date): string {
     const y = date.getFullYear();
@@ -88,103 +71,11 @@
     return map;
   });
 
-  const weekDates = $derived(getWeekDates());
+  const weekDates = $derived(() => getWeekDatesFromSteps(steps));
 
-  const hours = Array.from({ length: 16 }, (_, i) => i + 6);
+  const hours = DEFAULT_HOURS;
 
-  function getOverlappingStepsForDay(
-    dateStr: string,
-  ): Array<{ step: Step; index: number; totalCount: number }> {
-    const DAY_START = new Date(`${dateStr}T00:00:00`).getTime();
-    const DAY_END = DAY_START + 24 * 60 * 60 * 1000;
-
-    const daySteps = steps.filter(
-      (s) => s.start_at < DAY_END && s.end_at > DAY_START,
-    );
-
-    const enriched = daySteps.map((s) => {
-      const relStart = Math.max(
-        0,
-        Math.floor((Math.max(s.start_at, DAY_START) - DAY_START) / 60000),
-      );
-      const relEnd = Math.min(
-        24 * 60,
-        Math.ceil((Math.min(s.end_at, DAY_END) - DAY_START) / 60000),
-      );
-      return { step: s, relStart, relEnd };
-    });
-
-    enriched.sort((a, b) => a.relStart - b.relStart || a.relEnd - b.relEnd);
-
-    const positioned: {
-      step: Step;
-      index: number;
-      totalCount: number;
-      relStart: number;
-      relEnd: number;
-    }[] = [];
-
-    for (const item of enriched) {
-      const conflicting = enriched.filter(
-        (o) =>
-          o.step !== item.step &&
-          !(o.relEnd <= item.relStart || o.relStart >= item.relEnd),
-      );
-
-      const assignedIndex = conflicting.filter(
-        (o) => o.relStart < item.relStart,
-      ).length;
-      const maxOverlapCount = Math.max(1, conflicting.length + 1);
-
-      positioned.push({
-        step: item.step,
-        index: assignedIndex,
-        totalCount: maxOverlapCount,
-        relStart: item.relStart,
-        relEnd: item.relEnd,
-      });
-    }
-
-    return positioned;
-  }
-
-  function getEventsForCell(
-    dateStr: string,
-    hour: number,
-  ): Array<{ step: Step; index: number; totalCount: number }> {
-    const hourStart = hour * 60;
-    const hourEnd = (hour + 1) * 60;
-    const dayPositions = getOverlappingStepsForDay(dateStr) as Array<{
-      step: Step;
-      index: number;
-      totalCount: number;
-      relStart: number;
-      relEnd: number;
-    }>;
-
-    return dayPositions.filter(({ relStart, relEnd }) => {
-      return relStart < hourEnd && relEnd > hourStart;
-    });
-  }
-
-  function getEventStyle(
-    step: Step,
-    index: number,
-    totalCount: number,
-    relStart: number,
-    relEnd: number,
-  ): string {
-    const topOffset = ((relStart % 60) / 60) * 40;
-    const durationMinutes = Math.max(15, relEnd - relStart);
-    const height = Math.max((durationMinutes / 60) * 40, 38);
-    const width = 100 / totalCount;
-    const left = index * width;
-    return `top: ${topOffset}px; height: ${height}px; left: ${left}%; width: ${width}%;`;
-  }
-
-  function getEventCountForCell(dateStr: string, hour: number): number {
-    return getEventsForCell(dateStr, hour).length;
-  }
+  // helpers moved to weekview-utils.ts
 
   function handleEventClick(step: Step) {
     selectedStep = step;
@@ -210,8 +101,10 @@
         {#each weekDates as date}
           <div
             class="standard-autumn-week-day-header"
-            class:has-events={getOverlappingStepsForDay(formatDateKey(date))
-              .length > 0}
+            class:has-events={utilGetOverlappingStepsForDay(
+              steps,
+              formatDateKey(date),
+            ).length > 0}
           >
             <div class="standard-autumn-week-day-name">{getDayName(date)}</div>
             <div class="standard-autumn-week-day-date">
@@ -221,24 +114,38 @@
         {/each}
       </div>
 
-      <div class="standard-autumn-week-body">
+      <div
+        class="standard-autumn-week-body"
+        style="grid-template-columns: 60px repeat({weekDates.length}, 1fr);"
+      >
         {#each hours as hour}
           <div class="standard-autumn-week-time-label">
             {String(hour).padStart(2, "0")}:00
           </div>
-          {#each weekDates as date}
-            <div class="standard-autumn-week-cell">
-              {#each getEventsForCell(formatDateKey(date), hour) as { step, index, totalCount, relStart, relEnd }}
+        {/each}
+
+        {#each weekDates as date, di}
+          <div
+            class="standard-autumn-week-day-column"
+            style={`grid-column: ${di + 2}; grid-row: 1 / ${hours.length + 1};`}
+          >
+            <div class="standard-autumn-week-day-grid">
+              {#each hours as _}
+                <div class="standard-autumn-week-hour-row"></div>
+              {/each}
+            </div>
+            <div class="standard-autumn-week-events">
+              {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
                 {#if isSecretStep(step) && !hasEditPermission}
                   <button
                     type="button"
                     class="standard-autumn-week-event"
-                    style={getEventStyle(
-                      step,
-                      index,
-                      totalCount,
+                    style={utilGetEventStyleForDay(
+                      hours,
                       relStart,
                       relEnd,
+                      index,
+                      totalCount,
                     )}
                     title="Secret"
                     onclick={() => handleEventClick(step)}
@@ -252,12 +159,12 @@
                     class:standard-autumn-week-event-transport={isTransportType(
                       step.type,
                     )}
-                    style={getEventStyle(
-                      step,
-                      index,
-                      totalCount,
+                    style={utilGetEventStyleForDay(
+                      hours,
                       relStart,
                       relEnd,
+                      index,
+                      totalCount,
                     )}
                     title={step.title}
                     onclick={() => handleEventClick(step)}
@@ -272,7 +179,7 @@
                 {/if}
               {/each}
             </div>
-          {/each}
+          </div>
         {/each}
       </div>
     </div>
@@ -290,3 +197,60 @@
     {onDeleteStep}
   />
 {/if}
+
+<style>
+  .standard-autumn-week-body {
+    display: grid;
+    grid-auto-rows: 40px;
+    position: relative;
+    gap: 0;
+  }
+
+  .standard-autumn-week-day-column {
+    position: relative;
+    overflow: visible;
+  }
+
+  .standard-autumn-week-day-grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
+
+  .standard-autumn-week-hour-row {
+    height: 40px;
+    border-top: 1px solid var(--standard-autumn-line-color, #eee);
+    box-sizing: border-box;
+  }
+
+  .standard-autumn-week-events {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+
+  .standard-autumn-week-event {
+    position: absolute;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: var(--standard-autumn-event-bg, #fff);
+    border: 1px solid var(--standard-autumn-border, #e6e0d6);
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .standard-autumn-week-event-icon {
+    display: inline-flex;
+    align-items: center;
+  }
+</style>

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -213,7 +213,7 @@
 
   .standard-autumn-week-corner {
     background: var(--standard-autumn-header-bg);
-    border-bottom: 3px solid var(--standard-autumn-primary);
+    border-bottom: 1px solid var(--standard-autumn-primary);
     border-right: 1px solid var(--standard-autumn-border);
     display: flex;
     align-items: flex-end;

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -105,7 +105,6 @@
           </div>
           {#each weekDates() as date}
             <div class="standard-autumn-week-cell">
-              <div class="standard-autumn-week-cell-background"></div>
               <div class="standard-autumn-week-cell-content">
                 {#each utilGetOverlappingStepsForDay(steps, formatDateKey(date)) as { step, index, totalCount, relStart, relEnd }}
                   {#if isSecretStep(step) && !hasEditPermission}
@@ -254,6 +253,24 @@
     transition: opacity 0.2s;
   }
 
+  .standard-autumn-week-day-header::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: 
+      repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 10px,
+        rgba(var(--standard-autumn-primary-rgb), 0.03) 10px,
+        rgba(var(--standard-autumn-primary-rgb), 0.03) 11px
+      );
+    pointer-events: none;
+  }
+
   .standard-autumn-week-day-header.has-events::before {
     opacity: 1;
   }
@@ -310,6 +327,29 @@
     align-items: center;
     justify-content: flex-end;
     letter-spacing: 0.03em;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .standard-autumn-week-time-label::before {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 20%;
+    height: 1px;
+    background: var(--standard-autumn-border);
+    transform: translateY(-50%);
+  }
+
+  .standard-autumn-week-time-label::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    background: rgba(var(--standard-autumn-primary-rgb), 0.05);
   }
 
   .standard-autumn-week-cell {
@@ -324,12 +364,21 @@
     background: rgba(var(--standard-autumn-primary-rgb), 0.02);
   }
 
-  .standard-autumn-week-cell-background {
+  .standard-autumn-week-cell::before {
+    content: '';
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
+    background: 
+      repeating-linear-gradient(
+        90deg,
+        transparent,
+        transparent 20px,
+        rgba(var(--standard-autumn-primary-rgb), 0.01) 20px,
+        rgba(var(--standard-autumn-primary-rgb), 0.01) 21px
+      );
     pointer-events: none;
   }
 
@@ -343,7 +392,7 @@
     position: absolute;
     box-sizing: border-box;
     padding: 6px 8px;
-    border-radius: 6px;
+    border-radius: 8px;
     background: var(--standard-autumn-primary);
     color: #fff;
     border: 2px solid var(--standard-autumn-primary);
@@ -356,53 +405,94 @@
     z-index: 10;
     cursor: pointer;
     transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    box-shadow: 
+      0 2px 6px rgba(0, 0, 0, 0.12),
+      inset 0 1px 2px rgba(255, 255, 255, 0.15);
     margin: 2px;
     white-space: nowrap;
+    position: relative;
   }
 
   .standard-autumn-week-event::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: 2px;
+    left: 2px;
+    right: 2px;
     height: 2px;
-    background: rgba(255, 255, 255, 0.5);
-    border-radius: 6px 6px 0 0;
+    background: rgba(255, 255, 255, 0.6);
+    border-radius: 1px;
+  }
+
+  .standard-autumn-week-event::after {
+    content: '';
+    position: absolute;
+    bottom: 2px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.4);
+    border-radius: 0.5px;
   }
 
   .standard-autumn-week-event:hover {
     z-index: 20;
-    transform: translateY(-2px) scale(1.05);
-    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
+    transform: translateY(-4px) scale(1.06);
+    box-shadow: 
+      0 8px 16px rgba(0, 0, 0, 0.18),
+      inset 0 1px 2px rgba(255, 255, 255, 0.25);
   }
 
   .standard-autumn-week-event:active {
-    transform: translateY(0) scale(0.98);
+    transform: translateY(-1px) scale(0.98);
+    box-shadow: 
+      0 2px 4px rgba(0, 0, 0, 0.12),
+      inset 0 1px 2px rgba(255, 255, 255, 0.15);
   }
 
   .standard-autumn-week-event-transport {
     background: var(--standard-autumn-accent);
     border-color: var(--standard-autumn-accent);
     border-left: 4px solid rgba(255, 255, 255, 0.6);
+    padding-left: 6px;
+    box-shadow: 
+      0 2px 6px rgba(0, 0, 0, 0.15),
+      inset 0 0 8px rgba(255, 255, 255, 0.1);
+  }
+
+  .standard-autumn-week-event-transport::before {
+    background: rgba(255, 255, 255, 0.7);
+    animation: shimmer-top 3s ease-in-out infinite;
   }
 
   .standard-autumn-week-event-transport::after {
-    content: '⇒';
-    position: absolute;
+    content: '→';
+    position: absolute !important;
     right: 4px;
     top: 50%;
+    bottom: auto;
+    width: auto;
+    height: auto;
     transform: translateY(-50%);
     font-size: 0.9rem;
-    opacity: 0.8;
+    opacity: 0.9;
     animation: pulse-arrow 2s ease-in-out infinite;
+  }
+
+  @keyframes shimmer-top {
+    0%, 100% {
+      opacity: 0.6;
+    }
+    50% {
+      opacity: 0.9;
+    }
   }
 
   @keyframes pulse-arrow {
     0%, 100% {
       transform: translateY(-50%) translateX(0);
-      opacity: 0.8;
+      opacity: 0.9;
     }
     50% {
       transform: translateY(-50%) translateX(2px);

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -285,26 +285,29 @@
     font-size: 1rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.5);
   }
 
   .standard-autumn-week-day-date {
     font-size: 0.85rem;
     color: var(--standard-autumn-text-light);
     font-weight: 600;
+    letter-spacing: 0.02em;
   }
 
   .standard-autumn-week-day-header.has-events .standard-autumn-week-day-date {
     background: var(--standard-autumn-primary);
     color: #fff;
     padding: 4px 10px;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    display: flex;
+    border-radius: 6px;
+    width: auto;
+    height: auto;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
     font-weight: 700;
+    letter-spacing: 0.02em;
   }
 
   .standard-autumn-week-body {
@@ -313,6 +316,7 @@
     grid-template-columns: 70px repeat(var(--week-cols, 7), 1fr);
     grid-auto-rows: 56px;
     grid-auto-flow: row;
+    background: var(--standard-autumn-bg);
   }
 
   .standard-autumn-week-time-label {

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.svelte
@@ -116,15 +116,24 @@
 
     enriched.sort((a, b) => a.relStart - b.relStart || a.relEnd - b.relEnd);
 
-    const positioned: { step: Step; index: number; totalCount: number; relStart: number; relEnd: number }[] = [];
+    const positioned: {
+      step: Step;
+      index: number;
+      totalCount: number;
+      relStart: number;
+      relEnd: number;
+    }[] = [];
 
     for (const item of enriched) {
       const conflicting = enriched.filter(
         (o) =>
-          o.step !== item.step && !(o.relEnd <= item.relStart || o.relStart >= item.relEnd),
+          o.step !== item.step &&
+          !(o.relEnd <= item.relStart || o.relStart >= item.relEnd),
       );
 
-      const assignedIndex = conflicting.filter((o) => o.relStart < item.relStart).length;
+      const assignedIndex = conflicting.filter(
+        (o) => o.relStart < item.relStart,
+      ).length;
       const maxOverlapCount = Math.max(1, conflicting.length + 1);
 
       positioned.push({
@@ -201,7 +210,8 @@
         {#each weekDates as date}
           <div
             class="standard-autumn-week-day-header"
-            class:has-events={getOverlappingStepsForDay(formatDateKey(date)).length > 0}
+            class:has-events={getOverlappingStepsForDay(formatDateKey(date))
+              .length > 0}
           >
             <div class="standard-autumn-week-day-name">{getDayName(date)}</div>
             <div class="standard-autumn-week-day-date">
@@ -223,7 +233,13 @@
                   <button
                     type="button"
                     class="standard-autumn-week-event"
-                    style={getEventStyle(step, index, totalCount, relStart, relEnd)}
+                    style={getEventStyle(
+                      step,
+                      index,
+                      totalCount,
+                      relStart,
+                      relEnd,
+                    )}
                     title="Secret"
                     onclick={() => handleEventClick(step)}
                   >
@@ -236,7 +252,13 @@
                     class:standard-autumn-week-event-transport={isTransportType(
                       step.type,
                     )}
-                    style={getEventStyle(step, index, totalCount, relStart, relEnd)}
+                    style={getEventStyle(
+                      step,
+                      index,
+                      totalCount,
+                      relStart,
+                      relEnd,
+                    )}
                     title={step.title}
                     onclick={() => handleEventClick(step)}
                   >

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.test.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Step } from '@tabitabi/types';
-import { getOverlappingStepsForDay, getEventStyleForDay, DEFAULT_HOURS } from './weekview-utils';
+import { getOverlappingStepsForDay, getEventStyleForDay, getWeekHours, DEFAULT_HOURS } from './weekview-utils';
 
 describe('WeekView utils', () => {
   it('computes positions for a multi-hour event as a single positioned item', () => {
@@ -24,5 +24,25 @@ describe('WeekView utils', () => {
     const p = positioned[0];
     const style = getEventStyleForDay(DEFAULT_HOURS, p.relStart, p.relEnd, p.index, p.totalCount);
     expect(style).toMatch(/height:\s*\d+px/);
+  });
+
+  it('extends visible hours to 23:00 when a step exists after 21:00', () => {
+    const step: Step = {
+      id: 's-late',
+      itinerary_id: 'it1',
+      title: 'Late Event',
+      start_at: new Date(2024, 0, 2, 21, 45).getTime(),
+      end_at: new Date(2024, 0, 2, 22, 30).getTime(),
+      location: null,
+      notes: '',
+      type: 'normal:general',
+      is_hidden: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const hours = getWeekHours([step]);
+    expect(hours[0]).toBe(6);
+    expect(hours[hours.length - 1]).toBe(23);
   });
 });

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.test.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/WeekView.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import type { Step } from '@tabitabi/types';
+import { getOverlappingStepsForDay, getEventStyleForDay, DEFAULT_HOURS } from './weekview-utils';
+
+describe('WeekView utils', () => {
+  it('computes positions for a multi-hour event as a single positioned item', () => {
+    const date = '2024-01-02';
+    const step: Step = {
+      id: 's1',
+      itinerary_id: 'it1',
+      title: 'Long Event',
+      start_at: new Date(2024, 0, 2, 9, 0).getTime(),
+      end_at: new Date(2024, 0, 2, 11, 30).getTime(),
+      location: null,
+      notes: '',
+      type: 'normal:general',
+      is_hidden: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const positioned = getOverlappingStepsForDay([step], date);
+    expect(positioned.length).toBe(1);
+    const p = positioned[0];
+    const style = getEventStyleForDay(DEFAULT_HOURS, p.relStart, p.relEnd, p.index, p.totalCount);
+    expect(style).toMatch(/height:\s*\d+px/);
+  });
+});

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/weekview-utils.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/weekview-utils.ts
@@ -1,6 +1,29 @@
 import type { Step } from '@tabitabi/types';
 
+export const WEEK_VIEW_START_HOUR = 6;
+export const WEEK_VIEW_DEFAULT_END_HOUR = 21;
+export const WEEK_VIEW_EXTENDED_END_HOUR = 23;
+export const WEEK_VIEW_ROW_HEIGHT = 56;
+
 export const DEFAULT_HOURS = Array.from({ length: 16 }, (_, i) => i + 6);
+
+export function getWeekHours(steps: Step[]): number[] {
+  if (steps.length === 0) {
+    return DEFAULT_HOURS;
+  }
+
+  const showUntilEndOfDay = steps.some((step) => {
+    const start = new Date(step.start_at);
+    const end = new Date(step.end_at);
+    const startMinutes = start.getHours() * 60 + start.getMinutes();
+    const endMinutes = end.getHours() * 60 + end.getMinutes();
+    return startMinutes >= WEEK_VIEW_DEFAULT_END_HOUR * 60 || endMinutes >= WEEK_VIEW_DEFAULT_END_HOUR * 60;
+  });
+
+  const endHour = showUntilEndOfDay ? WEEK_VIEW_EXTENDED_END_HOUR : WEEK_VIEW_DEFAULT_END_HOUR;
+  const length = endHour - WEEK_VIEW_START_HOUR + 1;
+  return Array.from({ length }, (_, i) => i + WEEK_VIEW_START_HOUR);
+}
 
 export function getWeekDatesFromSteps(steps: Step[]): Date[] {
   if (steps.length === 0) return [];
@@ -84,8 +107,8 @@ export function getEventStyleForDay(
   const durationMinutes = Math.max(15, visibleEnd - visibleStart);
 
   const topOffsetMinutes = Math.max(0, visibleStart - hoursStartMin);
-  const top = (topOffsetMinutes / 60) * 40;
-  const height = Math.max((durationMinutes / 60) * 40, 38);
+  const top = (topOffsetMinutes / 60) * WEEK_VIEW_ROW_HEIGHT;
+  const height = Math.max((durationMinutes / 60) * WEEK_VIEW_ROW_HEIGHT, 38);
   const width = 100 / totalCount;
   const left = index * width;
 

--- a/apps/web/src/lib/themes/standard-seasons/shared/views/weekview-utils.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/views/weekview-utils.ts
@@ -1,0 +1,93 @@
+import type { Step } from '@tabitabi/types';
+
+export const DEFAULT_HOURS = Array.from({ length: 16 }, (_, i) => i + 6);
+
+export function getWeekDatesFromSteps(steps: Step[]): Date[] {
+  if (steps.length === 0) return [];
+
+  let minDay = Infinity;
+  let maxDay = -Infinity;
+
+  for (const s of steps) {
+    const sd = new Date(s.start_at);
+    sd.setHours(0, 0, 0, 0);
+    const ed = new Date(s.end_at);
+    ed.setHours(0, 0, 0, 0);
+    minDay = Math.min(minDay, sd.getTime());
+    maxDay = Math.max(maxDay, ed.getTime());
+  }
+
+  const weekDates: Date[] = [];
+  const current = new Date(minDay);
+  while (current.getTime() <= maxDay) {
+    weekDates.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return weekDates;
+}
+
+export function getOverlappingStepsForDay(
+  steps: Step[],
+  dateStr: string,
+): Array<{ step: Step; index: number; totalCount: number; relStart: number; relEnd: number }> {
+  const DAY_START = new Date(`${dateStr}T00:00:00`).getTime();
+  const DAY_END = DAY_START + 24 * 60 * 60 * 1000;
+
+  const daySteps = steps.filter((s) => s.start_at < DAY_END && s.end_at > DAY_START);
+
+  const enriched = daySteps.map((s) => {
+    const relStart = Math.max(0, Math.floor((Math.max(s.start_at, DAY_START) - DAY_START) / 60000));
+    const relEnd = Math.min(24 * 60, Math.ceil((Math.min(s.end_at, DAY_END) - DAY_START) / 60000));
+    return { step: s, relStart, relEnd };
+  });
+
+  enriched.sort((a, b) => a.relStart - b.relStart || a.relEnd - b.relEnd);
+
+  const positioned: {
+    step: Step;
+    index: number;
+    totalCount: number;
+    relStart: number;
+    relEnd: number;
+  }[] = [];
+
+  for (const item of enriched) {
+    const conflicting = enriched.filter((o) => o.step !== item.step && !(o.relEnd <= item.relStart || o.relStart >= item.relEnd));
+    const assignedIndex = conflicting.filter((o) => o.relStart < item.relStart).length;
+    const maxOverlapCount = Math.max(1, conflicting.length + 1);
+
+    positioned.push({
+      step: item.step,
+      index: assignedIndex,
+      totalCount: maxOverlapCount,
+      relStart: item.relStart,
+      relEnd: item.relEnd,
+    });
+  }
+
+  return positioned;
+}
+
+export function getEventStyleForDay(
+  hours: number[],
+  relStart: number,
+  relEnd: number,
+  index: number,
+  totalCount: number,
+): string {
+  const hoursStartMin = hours[0] * 60;
+  const hoursEndMin = (hours[hours.length - 1] + 1) * 60;
+
+  const visibleStart = Math.max(relStart, hoursStartMin);
+  const visibleEnd = Math.min(relEnd, hoursEndMin);
+  const durationMinutes = Math.max(15, visibleEnd - visibleStart);
+
+  const topOffsetMinutes = Math.max(0, visibleStart - hoursStartMin);
+  const top = (topOffsetMinutes / 60) * 40;
+  const height = Math.max((durationMinutes / 60) * 40, 38);
+  const width = 100 / totalCount;
+  const left = index * width;
+
+  return `top: ${top}px; height: ${height}px; left: ${left}%; width: ${width}%;`;
+}

--- a/apps/web/src/lib/themes/standard-seasons/spring/demo-data.ts
+++ b/apps/web/src/lib/themes/standard-seasons/spring/demo-data.ts
@@ -35,6 +35,18 @@ export function getDemoData(): DemoDataSet {
         updated_at: now,
       },
       {
+        id: 'demo-step-2-transport',
+        itinerary_id: 'demo',
+        title: '祇園から嵐山へ移動',
+        start_at: getTimestamp(0, '13:30'),
+        end_at: getEndTimestamp(getTimestamp(0, '13:30'), 60),
+        location: '京都市内',
+        notes: '{"text":"移動中：電車での移動を想定"}',
+        type: 'transport:train',
+        created_at: now,
+        updated_at: now,
+      },
+      {
         id: 'demo-step-3',
         itinerary_id: 'demo',
         title: '嵐山の桜散策',

--- a/apps/web/src/lib/themes/standard-seasons/spring/styles/variables.css
+++ b/apps/web/src/lib/themes/standard-seasons/spring/styles/variables.css
@@ -1,0 +1,7 @@
+/* Spring theme variables (delegates to shared variables by default)
+   Add season-specific overrides here when appropriate */
+@import '../../shared/styles/variables.css';
+
+:root {
+  /* Spring-specific overrides can be placed here */
+}

--- a/apps/web/src/lib/themes/standard-seasons/summer/demo-data.ts
+++ b/apps/web/src/lib/themes/standard-seasons/summer/demo-data.ts
@@ -24,6 +24,18 @@ export function getDemoData(): DemoDataSet {
         updated_at: now,
       },
       {
+        id: 'demo-step-1-transport',
+        itinerary_id: 'demo',
+        title: '空港からビーチへ移動',
+        start_at: getTimestamp(0, '11:15'),
+        end_at: getEndTimestamp(getTimestamp(0, '11:15'), 90),
+        location: '恩納村へ移動',
+        notes: '{"text":"レンタカーでの移動を想定"}',
+        type: 'transport:car',
+        created_at: now,
+        updated_at: now,
+      },
+      {
         id: 'demo-step-2',
         itinerary_id: 'demo',
         title: 'ビーチでシュノーケリング',

--- a/apps/web/src/lib/themes/standard-seasons/summer/styles/variables.css
+++ b/apps/web/src/lib/themes/standard-seasons/summer/styles/variables.css
@@ -1,0 +1,7 @@
+/* Summer theme variables (delegates to shared variables by default)
+   Add season-specific overrides here when appropriate */
+@import '../../shared/styles/variables.css';
+
+:root {
+  /* Summer-specific overrides can be placed here */
+}

--- a/apps/web/src/lib/themes/standard-seasons/winter/demo-data.ts
+++ b/apps/web/src/lib/themes/standard-seasons/winter/demo-data.ts
@@ -20,6 +20,7 @@ export function getDemoData(): DemoDataSet {
         end_at: getEndTimestamp(getTimestamp(0, '08:00'), 120),
         location: '東京駅',
         notes: '{"text":"北陸新幹線で長野へ"}',
+        type: 'transport:train',
         created_at: now,
         updated_at: now,
       },

--- a/apps/web/src/lib/themes/standard-seasons/winter/styles/variables.css
+++ b/apps/web/src/lib/themes/standard-seasons/winter/styles/variables.css
@@ -1,0 +1,7 @@
+/* Winter theme variables (delegates to shared variables by default)
+   Add season-specific overrides here when appropriate */
+@import '../../shared/styles/variables.css';
+
+:root {
+  /* Winter-specific overrides can be placed here */
+}

--- a/apps/web/tests/e2e/week-view-comprehensive.spec.ts
+++ b/apps/web/tests/e2e/week-view-comprehensive.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+
+test('@demo standard-seasons week view full test', async ({ page, browserName }) => {
+  // Only run on chromium for consistency
+  if (browserName !== 'chromium') return;
+
+  // Navigate to demo
+  console.log('🌐 Opening demo page...');
+  await page.goto('http://localhost:5173/?demo=true', { waitUntil: 'networkidle', timeout: 15000 });
+
+  // Wait for dynamic content
+  await page.waitForTimeout(1500);
+
+  // Find and click the Mode button to access view mode selector
+  console.log('🔍 Looking for Mode button...');
+  const buttons = await page.locator('button').all();
+
+  let modeFound = false;
+  for (const btn of buttons) {
+    const attrs = await btn.getAttribute('aria-label');
+    const text = await btn.textContent().catch(() => '');
+
+    if (attrs && attrs.includes('mode')) {
+      console.log('✅ Found mode button via aria-label');
+      await btn.click();
+      modeFound = true;
+      break;
+    } else if (text && text.toLowerCase().includes('mode')) {
+      console.log('✅ Found mode button via text');
+      await btn.click();
+      modeFound = true;
+      break;
+    }
+  }
+
+  if (!modeFound) {
+    console.log('⚠️  Could not find Mode button, checking for view mode selector');
+  }
+
+  await page.waitForTimeout(500);
+
+  // Try to find and click week view option
+  console.log('🔍 Looking for week view option...');
+  const allElements = await page.locator('*').all();
+  let weekClicked = false;
+
+  for (const elem of allElements) {
+    const text = await elem.textContent().catch(() => '');
+    if (text === 'Week' || text?.includes('week')) {
+      try {
+        await elem.click();
+        weekClicked = true;
+        console.log('✅ Clicked week view button');
+        break;
+      } catch {
+        // Element might not be clickable
+      }
+    }
+  }
+
+  await page.waitForTimeout(1500);
+
+  // Check if week view container exists
+  const weekView = page.locator('.standard-autumn-week-view');
+  const weekContainer = page.locator('.standard-autumn-week-container');
+
+  const weekViewVisible = await weekView.isVisible().catch(() => false);
+  const weekContainerVisible = await weekContainer.isVisible().catch(() => false);
+
+  console.log(`📊 Week view visible: ${weekViewVisible}`);
+  console.log(`📦 Week container visible: ${weekContainerVisible}`);
+
+  if (weekViewVisible || weekContainerVisible) {
+    console.log('✅ WeekView is rendering!');
+
+    // Count visible elements
+    const eventCount = await page.locator('.standard-autumn-week-event').count();
+    const cellCount = await page.locator('.standard-autumn-week-cell').count();
+    const headerCount = await page.locator('.standard-autumn-week-day-header').count;
+
+    console.log(`📍 Events visible: ${eventCount}`);
+    console.log(`📍 Cells visible: ${cellCount}`);
+    console.log(`📍 Headers visible: ${headerCount}`);
+
+    // Take screenshot
+    await page.screenshot({
+      path: 'week-view-active.png',
+      fullPage: true
+    });
+    console.log('📸 Screenshot saved: week-view-active.png');
+  } else {
+    console.log('❌ WeekView is NOT rendering');
+
+    // Take screenshot of what we see
+    await page.screenshot({
+      path: 'week-view-missing.png',
+      fullPage: true
+    });
+    console.log('📸 Screenshot saved: week-view-missing.png');
+
+    // Try to diagnose the issue
+    const dayCardView = page.locator('.standard-autumn-carousel').isVisible().catch(() => false);
+    if (await dayCardView) {
+      console.log('ℹ️ Day card view is visible instead');
+    }
+  }
+
+  // Log final state
+  console.log('✨ Test complete');
+});

--- a/apps/web/tests/e2e/week-view-test.spec.ts
+++ b/apps/web/tests/e2e/week-view-test.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('@demo week view rendering check', async ({ page }) => {
+  await page.goto('http://localhost:5173/?demo=true', { waitUntil: 'networkidle' });
+  
+  // Wait for the page to load
+  await page.waitForTimeout(2000);
+  
+  // Look for the Mode button (≣ icon) to access view mode selector
+  const modeButtons = await page.locator('[aria-label*="Mode"]').all();
+  if (modeButtons.length > 0) {
+    await modeButtons[0].click();
+    await page.waitForTimeout(500);
+  }
+  
+  // Try to find and click the week view option
+  const weekViewButton = await page.locator('button:has-text("week")').first();
+  if (await weekViewButton.isVisible()) {
+    await weekViewButton.click();
+    await page.waitForTimeout(1000);
+  }
+  
+  // Take a screenshot to see what's rendered
+  await page.screenshot({ path: 'week-view-current.png' });
+  
+  // Check if the week view container exists
+  const weekContainer = page.locator('.standard-autumn-week-view');
+  const isVisible = await weekContainer.isVisible().catch(() => false);
+  console.log('Week view container visible:', isVisible);
+  
+  // Check if it has content
+  const weekElements = await page.locator('.standard-autumn-week-*').count();
+  console.log('Week view elements count:', weekElements);
+});

--- a/apps/web/tests/e2e/week-view-test.spec.ts
+++ b/apps/web/tests/e2e/week-view-test.spec.ts
@@ -2,32 +2,32 @@ import { test, expect } from '@playwright/test';
 
 test('@demo week view rendering check', async ({ page }) => {
   await page.goto('http://localhost:5173/?demo=true', { waitUntil: 'networkidle' });
-  
+
   // Wait for the page to load
   await page.waitForTimeout(2000);
-  
+
   // Look for the Mode button (≣ icon) to access view mode selector
   const modeButtons = await page.locator('[aria-label*="Mode"]').all();
   if (modeButtons.length > 0) {
     await modeButtons[0].click();
     await page.waitForTimeout(500);
   }
-  
+
   // Try to find and click the week view option
   const weekViewButton = await page.locator('button:has-text("week")').first();
   if (await weekViewButton.isVisible()) {
     await weekViewButton.click();
     await page.waitForTimeout(1000);
   }
-  
+
   // Take a screenshot to see what's rendered
   await page.screenshot({ path: 'week-view-current.png' });
-  
+
   // Check if the week view container exists
   const weekContainer = page.locator('.standard-autumn-week-view');
   const isVisible = await weekContainer.isVisible().catch(() => false);
   console.log('Week view container visible:', isVisible);
-  
+
   // Check if it has content
   const weekElements = await page.locator('.standard-autumn-week-*').count();
   console.log('Week view elements count:', weekElements);

--- a/apps/web/tests/e2e/week-view-visual.spec.ts
+++ b/apps/web/tests/e2e/week-view-visual.spec.ts
@@ -1,0 +1,53 @@
+import { test } from '@playwright/test';
+
+test('@quick week view visualization', async ({ page }) => {
+  // Go to demo page
+  await page.goto('http://localhost:5173/?demo=true', { waitUntil: 'networkidle', timeout: 10000 });
+  
+  // Wait for content to fully load
+  await page.waitForTimeout(2000);
+  
+  // Try to access the mode selector button (view mode switch)
+  const buttons = await page.locator('button').all();
+  let found = false;
+  for (const btn of buttons) {
+    const text = await btn.textContent();
+    if (text && text.includes('Mode')) {
+      await btn.click();
+      found = true;
+      break;
+    }
+  }
+  
+  if (!found) {
+    // Try using aria-label for Mode button
+    const modeBtn = page.locator('[aria-label*="mode"]').first();
+    if (await modeBtn.isVisible()) {
+      await modeBtn.click();
+    }
+  }
+  
+  await page.waitForTimeout(500);
+  
+  // Look for week view button
+  const options = await page.locator('[role="button"], button').all();
+  for (const opt of options) {
+    const text = await opt.textContent();
+    if (text && text.includes('Week')) {
+      await opt.click();
+      break;
+    }
+  }
+  
+  await page.waitForTimeout(1000);
+  
+  // Check if week view is visible and take screenshot
+  const weekView = page.locator('.standard-autumn-week-view').first();
+  if (await weekView.isVisible()) {
+    console.log('✅ Week view is visible');
+    await page.screenshot({ path: 'week-view-demo.png', fullPage: true });
+  } else {
+    console.log('❌ Week view is not visible');
+    await page.screenshot({ path: 'week-view-missing.png', fullPage: true });
+  }
+});

--- a/apps/web/tests/e2e/week-view-visual.spec.ts
+++ b/apps/web/tests/e2e/week-view-visual.spec.ts
@@ -3,10 +3,10 @@ import { test } from '@playwright/test';
 test('@quick week view visualization', async ({ page }) => {
   // Go to demo page
   await page.goto('http://localhost:5173/?demo=true', { waitUntil: 'networkidle', timeout: 10000 });
-  
+
   // Wait for content to fully load
   await page.waitForTimeout(2000);
-  
+
   // Try to access the mode selector button (view mode switch)
   const buttons = await page.locator('button').all();
   let found = false;
@@ -18,7 +18,7 @@ test('@quick week view visualization', async ({ page }) => {
       break;
     }
   }
-  
+
   if (!found) {
     // Try using aria-label for Mode button
     const modeBtn = page.locator('[aria-label*="mode"]').first();
@@ -26,9 +26,9 @@ test('@quick week view visualization', async ({ page }) => {
       await modeBtn.click();
     }
   }
-  
+
   await page.waitForTimeout(500);
-  
+
   // Look for week view button
   const options = await page.locator('[role="button"], button').all();
   for (const opt of options) {
@@ -38,9 +38,9 @@ test('@quick week view visualization', async ({ page }) => {
       break;
     }
   }
-  
+
   await page.waitForTimeout(1000);
-  
+
   // Check if week view is visible and take screenshot
   const weekView = page.locator('.standard-autumn-week-view').first();
   if (await weekView.isVisible()) {


### PR DESCRIPTION
概要:
- アイコンを `shared/components/icons` に統合
- 各季節のデモに移動(transport)ステップを追加
- 日カードに移動ビジュアルを追加、週ビューの多日表示と時刻バリデーションを修正

テスト:
- apps/web: 28 passed
- api: 32 passed

確認ポイント:
- UI を手動で確認してください（移動表示・編集フォームの時刻同期）
