### PR TITLE
fix(auth): fix reactive login state and add navigation after auth actions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "migrations:apply": "wrangler d1 migrations apply tabitabi-db",
+    "migrations:apply": "wrangler d1 migrations apply tabitabi",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/apps/api/wrangler.toml.example
+++ b/apps/api/wrangler.toml.example
@@ -7,12 +7,13 @@ enabled = true
 
 [[d1_databases]]
 binding = "DB"
-database_name = "tabitabi"
+database_name = "tabitabi-db"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"
 
 [vars]
 ALLOWED_ORIGINS = "*"
+JWT_SECRET = "local-dev-secret"
 
 [env.production]
 name = "tabitabi-api"
@@ -26,7 +27,7 @@ enabled = true
 
 [[env.production.d1_databases]]
 binding = "DB"
-database_name = "tabitabi"
+database_name = "tabitabi-db"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"
 
@@ -40,6 +41,6 @@ enabled = true
 
 [[env.preview.d1_databases]]
 binding = "DB"
-database_name = "tabitabi"
+database_name = "tabitabi-db"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"

--- a/apps/api/wrangler.toml.example
+++ b/apps/api/wrangler.toml.example
@@ -13,6 +13,7 @@ migrations_dir = "./migrations"
 
 [vars]
 ALLOWED_ORIGINS = "*"
+JWT_SECRET = "local-dev-secret"
 
 [env.production]
 name = "tabitabi-api"

--- a/apps/api/wrangler.toml.example
+++ b/apps/api/wrangler.toml.example
@@ -7,13 +7,12 @@ enabled = true
 
 [[d1_databases]]
 binding = "DB"
-database_name = "tabitabi-db"
+database_name = "tabitabi"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"
 
 [vars]
 ALLOWED_ORIGINS = "*"
-JWT_SECRET = "local-dev-secret"
 
 [env.production]
 name = "tabitabi-api"
@@ -27,7 +26,7 @@ enabled = true
 
 [[env.production.d1_databases]]
 binding = "DB"
-database_name = "tabitabi-db"
+database_name = "tabitabi"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"
 
@@ -41,6 +40,6 @@ enabled = true
 
 [[env.preview.d1_databases]]
 binding = "DB"
-database_name = "tabitabi-db"
+database_name = "tabitabi"
 database_id = "PLACEHOLDER_DATABASE_ID"
 migrations_dir = "./migrations"

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -151,7 +151,7 @@
           {#if mode === "login"}
             アカウントをお持ちでない方は
             <button onclick={() => { mode = "register"; formError = null; }} class="text-indigo-600 hover:underline">
-              ���規登録
+              新規登録
             </button>
           {:else}
             すでにアカウントをお持ちの方は

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -56,7 +56,7 @@
         userAuth.setSession(result.token, result.user);
       }
       username = userAuth.getUser()?.username ?? null;
-      loggedIn = true;
+      loggedIn = userAuth.isLoggedIn();
       await loadBookmarks();
     } catch (e) {
       formError = e instanceof Error ? e.message : "エラーが発生しました";

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
   import { userApi } from "$lib/api/user";
   import { userAuth } from "$lib/user-auth";
   import type { UserBookmarkWithItinerary } from "@tabitabi/types";
 
+  let loggedIn = $state(false);
   let bookmarks: UserBookmarkWithItinerary[] = $state([]);
   let loading = $state(true);
   let error = $state<string | null>(null);
@@ -18,7 +20,8 @@
   let submitting = $state(false);
 
   onMount(async () => {
-    if (!userAuth.isLoggedIn()) {
+    loggedIn = userAuth.isLoggedIn();
+    if (!loggedIn) {
       loading = false;
       return;
     }
@@ -53,6 +56,7 @@
         userAuth.setSession(result.token, result.user);
       }
       username = userAuth.getUser()?.username ?? null;
+      loggedIn = true;
       await loadBookmarks();
     } catch (e) {
       formError = e instanceof Error ? e.message : "エラーが発生しました";
@@ -63,10 +67,12 @@
 
   function handleLogout() {
     userAuth.clearSession();
+    loggedIn = false;
     bookmarks = [];
     username = null;
     email = "";
     password = "";
+    goto("/");
   }
 
   async function toggleVisibility(itineraryId: string, current: boolean) {
@@ -96,7 +102,7 @@
 <div class="min-h-screen bg-gray-50">
   <div class="max-w-3xl mx-auto px-4 py-8">
 
-    {#if !userAuth.isLoggedIn()}
+    {#if !loggedIn}
       <!-- ログイン / 新規登録フォーム -->
       <div class="bg-white rounded-lg shadow-md p-6 max-w-md mx-auto">
         <h1 class="text-2xl font-bold text-gray-900 mb-6">

--- a/apps/web/src/routes/users/[username]/+page.svelte
+++ b/apps/web/src/routes/users/[username]/+page.svelte
@@ -11,6 +11,11 @@
   let notFound = $state(false);
 
   onMount(async () => {
+    if (!username) {
+      notFound = true;
+      loading = false;
+      return;
+    }
     try {
       const result = await userApi.getPublicBookmarks(username);
       bookmarks = result.bookmarks;


### PR DESCRIPTION
## Summary

- ログイン/登録後にマイページが即座に表示されるよう修正（Svelte 5 runesの reactivity対応）
- ログアウト後に `/` へ遷移
- `[username]/+page.svelte` の型エラー修正（`params.username` が `undefined` になりうる）

## 背景

`userAuth.isLoggedIn()` はlocalStorageを直接読む関数のため、Svelte 5のテンプレート内で呼び出してもリアクティブに更新されなかった。
ログイン/登録成功後もフォームが表示されたままになる問題を、`$state` 変数に置き換えることで修正。

## Test plan

- [ ] `/profile` にアクセスしてログインフォームが表示される
- [ ] ログイン成功後、マイページ（ブックマーク一覧）が即座に表示される
- [ ] 新規登録成功後、マイページが即座に表示される
- [ ] ログアウト後、`/` にリダイレクトされる
- [ ] `/users/[username]` の公開プロフィールページが正常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)