### PR TITLE
feat(share): 共有URLの発行・公開スナップショット機能を追加 (SOR-20)

### DIFF
--- a/apps/api/migrations/0015_add_source_itinerary_id.sql
+++ b/apps/api/migrations/0015_add_source_itinerary_id.sql
@@ -1,0 +1,3 @@
+-- Add source_itinerary_id to track shared snapshots
+-- When set, this itinerary is a shared snapshot (view-only) of the source itinerary
+ALTER TABLE itineraries ADD COLUMN source_itinerary_id TEXT;

--- a/apps/api/migrations/0015_add_source_itinerary_id.sql
+++ b/apps/api/migrations/0015_add_source_itinerary_id.sql
@@ -1,3 +1,6 @@
 -- Add source_itinerary_id to track shared snapshots
 -- When set, this itinerary is a shared snapshot (view-only) of the source itinerary
 ALTER TABLE itineraries ADD COLUMN source_itinerary_id TEXT;
+
+-- Unique partial index: at most one shared snapshot per source itinerary
+CREATE UNIQUE INDEX idx_itineraries_source_id ON itineraries(source_itinerary_id) WHERE source_itinerary_id IS NOT NULL;

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -57,6 +57,10 @@ itineraries.put('/:id', optionalAuthMiddleware, async (c) => {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
   }
 
+  if (existing.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot edit a shared snapshot' } }, 403);
+  }
+
   if (existing.password) {
     const shioriId = c.get('shioriId');
 
@@ -153,6 +157,10 @@ itineraries.delete('/:id', optionalAuthMiddleware, async (c) => {
 
   if (!existing) {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
+  }
+
+  if (existing.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot delete a shared snapshot' } }, 403);
   }
 
   if (existing.password) {

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -77,6 +77,40 @@ itineraries.put('/:id', optionalAuthMiddleware, async (c) => {
   return c.json({ success: true, data: service.toResponseItinerary(data) });
 });
 
+itineraries.post('/:id/publish', optionalAuthMiddleware, async (c) => {
+  const id = c.req.param('id');
+  const service = new ItineraryService(c.env.DB);
+  const existing = await service.get(id);
+
+  if (!existing) {
+    return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
+  }
+
+  if (existing.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot publish a shared snapshot' } }, 403);
+  }
+
+  if (existing.password) {
+    const shioriId = c.get('shioriId');
+    if (id !== shioriId) {
+      return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'You can only publish your own itinerary' } }, 403);
+    }
+  }
+
+  let snapshot: Awaited<ReturnType<typeof service.publish>>;
+  try {
+    snapshot = await service.publish(id);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : '';
+    if (msg === 'NOT_FOUND') {
+      return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
+    }
+    throw e;
+  }
+
+  return c.json({ success: true, data: { id: snapshot.id } });
+});
+
 itineraries.post('/:id/fork', userAuthMiddleware, async (c) => {
   const sourceId = c.req.param('id');
   const userId = c.get('userId');

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -90,6 +90,9 @@ itineraries.post('/:id/publish', optionalAuthMiddleware, async (c) => {
     return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot publish a shared snapshot' } }, 403);
   }
 
+  // For password-protected itineraries, verify the itinerary token.
+  // Note: public (no-password) itineraries have no server-side ownership concept;
+  // anyone who knows the ID can publish. This is consistent with the current edit model.
   if (existing.password) {
     const shioriId = c.get('shioriId');
     if (id !== shioriId) {
@@ -97,16 +100,7 @@ itineraries.post('/:id/publish', optionalAuthMiddleware, async (c) => {
     }
   }
 
-  let snapshot: Awaited<ReturnType<typeof service.publish>>;
-  try {
-    snapshot = await service.publish(id);
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : '';
-    if (msg === 'NOT_FOUND') {
-      return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
-    }
-    throw e;
-  }
+  const snapshot = await service.publish(id);
 
   return c.json({ success: true, data: { id: snapshot.id } });
 });

--- a/apps/api/src/routes/steps.ts
+++ b/apps/api/src/routes/steps.ts
@@ -93,6 +93,10 @@ steps.post('/', async (c) => {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
   }
 
+  if (itinerary.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot modify steps of a shared snapshot' } }, 403);
+  }
+
   if (itinerary.password) {
     const token = extractBearerToken(c.req.header('Authorization'));
     const payload = token ? await verifyToken(token, c.env.JWT_SECRET) : null;
@@ -131,6 +135,9 @@ steps.put('/:stepId', async (c) => {
   const itinerary = await itineraryService.get(existingStep.itinerary_id);
   if (!itinerary) {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
+  }
+  if (itinerary.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot modify steps of a shared snapshot' } }, 403);
   }
   if (itinerary.password) {
     const token = extractBearerToken(c.req.header('Authorization'));
@@ -179,6 +186,9 @@ steps.delete('/:stepId', async (c) => {
   const itinerary = await itineraryService.get(existingStep.itinerary_id);
   if (!itinerary) {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Itinerary not found' } }, 404);
+  }
+  if (itinerary.source_itinerary_id) {
+    return c.json({ success: false, error: { code: 'FORBIDDEN', message: 'Cannot modify steps of a shared snapshot' } }, 403);
   }
   if (itinerary.password) {
     const token = extractBearerToken(c.req.header('Authorization'));

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { Env, Variables } from '../utils';
 import { UserService } from '../services/user.service';
+import { ItineraryService } from '../services/itinerary.service';
 import { userAuthMiddleware } from '../middleware/auth';
 import { generateUserToken } from '../utils/jwt';
 import type { RegisterInput, LoginInput, UpdateVisibilityInput, SyncBookmarksInput, UpdateProfileInput, UpdatePasswordInput } from '@tabitabi/types';
@@ -207,6 +208,18 @@ users.patch('/me/bookmarks/:itineraryId/visibility', userAuthMiddleware, async (
 
   if (!result) {
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Bookmark not found' } }, 404);
+  }
+
+  // 公開にした場合、共有スナップショットを自動生成してブックマークに追加する
+  if (input.is_visible) {
+    try {
+      const itineraryService = new ItineraryService(c.env.DB);
+      const snapshot = await itineraryService.publish(itineraryId);
+      await service.syncBookmarks(userId, [snapshot.id]);
+      await service.updateBookmarkVisibility(userId, snapshot.id, true);
+    } catch {
+      // 非致命的: 元しおりの公開状態は変更済み、スナップショット生成は後から同期可能
+    }
   }
 
   return c.json({ success: true, data: result });

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -210,13 +210,17 @@ users.patch('/me/bookmarks/:itineraryId/visibility', userAuthMiddleware, async (
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Bookmark not found' } }, 404);
   }
 
-  // 公開にした場合、共有スナップショットを自動生成してブックマークに追加する
+  // 公開にした場合、パスワードなしのしおりのみ共有スナップショットを自動生成する
+  // パスワード付きしおりはしおりトークンが必要なため、ここでは自動生成しない
   if (input.is_visible) {
     try {
       const itineraryService = new ItineraryService(c.env.DB);
-      const snapshot = await itineraryService.publish(itineraryId);
-      await service.syncBookmarks(userId, [snapshot.id]);
-      await service.updateBookmarkVisibility(userId, snapshot.id, true);
+      const itinerary = await itineraryService.get(itineraryId);
+      if (itinerary && !itinerary.password) {
+        const snapshot = await itineraryService.publish(itineraryId);
+        await service.syncBookmarks(userId, [snapshot.id]);
+        await service.updateBookmarkVisibility(userId, snapshot.id, true);
+      }
     } catch {
       // 非致命的: 元しおりの公開状態は変更済み、スナップショット生成は後から同期可能
     }

--- a/apps/api/src/services/itinerary.service.ts
+++ b/apps/api/src/services/itinerary.service.ts
@@ -255,7 +255,7 @@ export class ItineraryService {
       .all();
     const rows = sourceSteps.results ?? [];
 
-    const existing = await this.db
+    let existing = await this.db
       .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
       .bind(sourceId)
       .first<{ id: string }>();
@@ -268,15 +268,28 @@ export class ItineraryService {
           .bind(generateId(), newId, row.title, row.start_at, row.end_at, row.location, row.notes, row.type, row.is_all_day, now, now)
       );
 
-      await this.db.batch([
-        this.db
-          .prepare('INSERT INTO itineraries (id, title, theme_id, memo, password, source_itinerary_id, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?, ?)')
-          .bind(newId, source.title, source.theme_id, source.memo, sourceId, now, now),
-        ...stepStatements,
-      ]);
+      try {
+        await this.db.batch([
+          this.db
+            .prepare('INSERT INTO itineraries (id, title, theme_id, memo, password, source_itinerary_id, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?, ?)')
+            .bind(newId, source.title, source.theme_id, source.memo, sourceId, now, now),
+          ...stepStatements,
+        ]);
+        return (await this.get(newId))!;
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '';
+        if (!msg.includes('UNIQUE constraint failed')) throw e;
+        // Concurrent publish race: fall through to update the snapshot created by the other request
+        const concurrent = await this.db
+          .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
+          .bind(sourceId)
+          .first<{ id: string }>();
+        if (!concurrent) throw e;
+        existing = concurrent;
+      }
+    }
 
-      return (await this.get(newId))!;
-    } else {
+    {
       const sharedId = existing.id;
       const stepStatements = rows.map(row =>
         this.db

--- a/apps/api/src/services/itinerary.service.ts
+++ b/apps/api/src/services/itinerary.service.ts
@@ -242,6 +242,62 @@ export class ItineraryService {
     return { itinerary: forked!, steps: rows.length };
   }
 
+  async publish(sourceId: string): Promise<Itinerary> {
+    const source = await this.get(sourceId);
+    if (!source) throw new Error('NOT_FOUND');
+    if (source.source_itinerary_id) throw new Error('CANNOT_PUBLISH_SNAPSHOT');
+
+    const now = getCurrentTimestamp();
+
+    const sourceSteps = await this.db
+      .prepare('SELECT title, start_at, end_at, location, notes, type, is_all_day FROM steps WHERE itinerary_id = ? ORDER BY start_at ASC')
+      .bind(sourceId)
+      .all();
+    const rows = sourceSteps.results ?? [];
+
+    const existing = await this.db
+      .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
+      .bind(sourceId)
+      .first<{ id: string }>();
+
+    if (!existing) {
+      const newId = generateId();
+      const stepStatements = rows.map(row =>
+        this.db
+          .prepare('INSERT INTO steps (id, itinerary_id, title, start_at, end_at, location, notes, type, is_all_day, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+          .bind(generateId(), newId, row.title, row.start_at, row.end_at, row.location, row.notes, row.type, row.is_all_day, now, now)
+      );
+
+      await this.db.batch([
+        this.db
+          .prepare('INSERT INTO itineraries (id, title, theme_id, memo, password, source_itinerary_id, created_at, updated_at) VALUES (?, ?, ?, ?, NULL, ?, ?, ?)')
+          .bind(newId, source.title, source.theme_id, source.memo, sourceId, now, now),
+        ...stepStatements,
+      ]);
+
+      return (await this.get(newId))!;
+    } else {
+      const sharedId = existing.id;
+      const stepStatements = rows.map(row =>
+        this.db
+          .prepare('INSERT INTO steps (id, itinerary_id, title, start_at, end_at, location, notes, type, is_all_day, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+          .bind(generateId(), sharedId, row.title, row.start_at, row.end_at, row.location, row.notes, row.type, row.is_all_day, now, now)
+      );
+
+      await this.db.batch([
+        this.db
+          .prepare('UPDATE itineraries SET title = ?, theme_id = ?, memo = ?, updated_at = ? WHERE id = ?')
+          .bind(source.title, source.theme_id, source.memo, now, sharedId),
+        this.db
+          .prepare('DELETE FROM steps WHERE itinerary_id = ?')
+          .bind(sharedId),
+        ...stepStatements,
+      ]);
+
+      return (await this.get(sharedId))!;
+    }
+  }
+
   async delete(id: string): Promise<boolean> {
     // Foreign key cascade handles secrets, walica, and fork_stats tables
     const result = await this.db
@@ -270,6 +326,10 @@ export class ItineraryService {
         enabled: row.secret_enabled === 1,
         offset_minutes: row.secret_offset as number,
       };
+    }
+
+    if (row.source_itinerary_id) {
+      itinerary.source_itinerary_id = row.source_itinerary_id as string;
     }
 
     return itinerary;

--- a/apps/api/src/services/user.service.ts
+++ b/apps/api/src/services/user.service.ts
@@ -88,7 +88,7 @@ export class UserService {
     return result ?? null;
   }
 
-  // 自分の全しおり一覧（公開/非公開含む）
+  // 自分の全しおり一覧（公開/非公開含む、元のしおりのみ）
   async getMyBookmarks(userId: string): Promise<UserBookmarkWithItinerary[]> {
     const results = await this.db
       .prepare(`
@@ -96,11 +96,14 @@ export class UserService {
           ub.user_id, ub.itinerary_id, ub.is_visible, ub.created_at, ub.updated_at,
           i.title, i.theme_id,
           CASE WHEN i.password IS NOT NULL THEN 1 ELSE 0 END as is_password_protected,
+          i.updated_at as itinerary_updated_at,
           i.source_itinerary_id,
-          (SELECT id FROM itineraries WHERE source_itinerary_id = ub.itinerary_id LIMIT 1) as shared_itinerary_id
+          (SELECT id FROM itineraries WHERE source_itinerary_id = ub.itinerary_id LIMIT 1) as shared_itinerary_id,
+          (SELECT updated_at FROM itineraries WHERE source_itinerary_id = ub.itinerary_id LIMIT 1) as shared_updated_at
         FROM user_bookmarks ub
         JOIN itineraries i ON ub.itinerary_id = i.id
         WHERE ub.user_id = ?
+          AND i.source_itinerary_id IS NULL
         ORDER BY ub.created_at DESC
       `)
       .bind(userId)
@@ -115,8 +118,10 @@ export class UserService {
       title: row.title as string,
       theme_id: row.theme_id as string,
       is_password_protected: row.is_password_protected === 1,
+      itinerary_updated_at: row.itinerary_updated_at as string,
       source_itinerary_id: (row.source_itinerary_id as string | null) ?? null,
       shared_itinerary_id: (row.shared_itinerary_id as string | null) ?? null,
+      shared_updated_at: (row.shared_updated_at as string | null) ?? null,
     }));
   }
 
@@ -132,6 +137,7 @@ export class UserService {
         WHERE u.username = ?
           AND ub.is_visible = 1
           AND i.password IS NULL
+          AND i.source_itinerary_id IS NOT NULL
         ORDER BY i.created_at DESC
       `)
       .bind(username)
@@ -152,6 +158,7 @@ export class UserService {
         JOIN users u ON ub.user_id = u.id
         WHERE ub.is_visible = 1
           AND i.password IS NULL
+          AND i.source_itinerary_id IS NOT NULL
         ORDER BY i.created_at DESC
         LIMIT ? OFFSET ?
       `)

--- a/apps/api/src/services/user.service.ts
+++ b/apps/api/src/services/user.service.ts
@@ -95,7 +95,9 @@ export class UserService {
         SELECT
           ub.user_id, ub.itinerary_id, ub.is_visible, ub.created_at, ub.updated_at,
           i.title, i.theme_id,
-          CASE WHEN i.password IS NOT NULL THEN 1 ELSE 0 END as is_password_protected
+          CASE WHEN i.password IS NOT NULL THEN 1 ELSE 0 END as is_password_protected,
+          i.source_itinerary_id,
+          (SELECT id FROM itineraries WHERE source_itinerary_id = ub.itinerary_id LIMIT 1) as shared_itinerary_id
         FROM user_bookmarks ub
         JOIN itineraries i ON ub.itinerary_id = i.id
         WHERE ub.user_id = ?
@@ -113,6 +115,8 @@ export class UserService {
       title: row.title as string,
       theme_id: row.theme_id as string,
       is_password_protected: row.is_password_protected === 1,
+      source_itinerary_id: (row.source_itinerary_id as string | null) ?? null,
+      shared_itinerary_id: (row.shared_itinerary_id as string | null) ?? null,
     }));
   }
 

--- a/apps/api/test/itineraries.test.ts
+++ b/apps/api/test/itineraries.test.ts
@@ -14,6 +14,7 @@ async function applyMigrations(db: D1Database) {
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_itineraries_source_id ON itineraries(source_itinerary_id) WHERE source_itinerary_id IS NOT NULL;`,
     `CREATE TABLE IF NOT EXISTS steps (
       id TEXT PRIMARY KEY,
       itinerary_id TEXT NOT NULL,
@@ -526,5 +527,41 @@ describe('POST /api/v1/itineraries/:id/publish', () => {
       headers: { 'Content-Type': 'application/json' },
     }, env);
     expect(res.status).toBe(404);
+  });
+
+  it('returns 403 for password-protected itinerary without valid token', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '秘密のしおり', password: 'secret123' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    const res = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    expect(res.status).toBe(403);
+    const json = await res.json() as { error: { code: string } };
+    expect(json.error.code).toBe('FORBIDDEN');
+  });
+
+  it('publishes a password-protected itinerary with valid shiori token', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '秘密のしおり', password: 'secret123' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    const res = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${original.token}` },
+    }, env);
+    expect(res.status).toBe(200);
+
+    const { success, data } = await res.json() as any;
+    expect(success).toBe(true);
+    expect(data.id).toBeDefined();
   });
 });

--- a/apps/api/test/itineraries.test.ts
+++ b/apps/api/test/itineraries.test.ts
@@ -10,6 +10,7 @@ async function applyMigrations(db: D1Database) {
       theme_id TEXT NOT NULL DEFAULT 'standard-autumn',
       memo TEXT,
       password TEXT,
+      source_itinerary_id TEXT,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,
@@ -395,6 +396,134 @@ describe('POST /api/v1/itineraries/:id/fork', () => {
     const res = await app.request('/api/v1/itineraries/nonexistent-id/fork', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    }, env);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/v1/itineraries/:id/publish', () => {
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM steps').run();
+    await env.DB.prepare('DELETE FROM itinerary_secrets').run();
+    await env.DB.prepare('DELETE FROM itinerary_walica_settings').run();
+    await env.DB.prepare('DELETE FROM itineraries').run();
+    await env.DB.prepare('DELETE FROM users').run();
+  });
+
+  it('creates a shared snapshot from a public itinerary', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '旅のしおり', memo: '{"text":"メモ"}' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    const publishRes = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    expect(publishRes.status).toBe(200);
+
+    const { success, data } = await publishRes.json() as any;
+    expect(success).toBe(true);
+    expect(data.id).toBeDefined();
+    expect(data.id).not.toBe(original.id);
+
+    const snapshotRes = await app.request(`/api/v1/itineraries/${data.id}`, {}, env);
+    const { data: snapshot } = await snapshotRes.json() as any;
+    expect(snapshot.title).toBe('旅のしおり');
+    expect(snapshot.source_itinerary_id).toBe(original.id);
+  });
+
+  it('is idempotent — calling publish again updates the snapshot', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '初期タイトル' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    const firstPublish = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    const { data: first } = await firstPublish.json() as any;
+
+    await app.request(`/api/v1/itineraries/${original.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${original.token}` },
+      body: JSON.stringify({ title: '更新後タイトル' }),
+    }, env);
+
+    const secondPublish = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${original.token}` },
+    }, env);
+    expect(secondPublish.status).toBe(200);
+    const { data: second } = await secondPublish.json() as any;
+
+    expect(second.id).toBe(first.id);
+
+    const snapshotRes = await app.request(`/api/v1/itineraries/${second.id}`, {}, env);
+    const { data: snapshot } = await snapshotRes.json() as any;
+    expect(snapshot.title).toBe('更新後タイトル');
+  });
+
+  it('copies steps to the shared snapshot', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'ステップ付きしおり' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    await app.request('/api/v1/steps', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ itinerary_id: original.id, title: '観光スポット', start_at: 1700000000000, end_at: 1700003600000 }),
+    }, env);
+
+    const publishRes = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    const { data: pub } = await publishRes.json() as any;
+
+    const stepsRes = await app.request(`/api/v1/steps?itinerary_id=${pub.id}`, {}, env);
+    const { data: steps } = await stepsRes.json() as any;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].title).toBe('観光スポット');
+    expect(steps[0].itinerary_id).toBe(pub.id);
+  });
+
+  it('returns 403 when publishing a shared snapshot', async () => {
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'オリジナル' }),
+    }, env);
+    const { data: original } = await createRes.json() as any;
+
+    const publishRes = await app.request(`/api/v1/itineraries/${original.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    const { data: snapshot } = await publishRes.json() as any;
+
+    const rePub = await app.request(`/api/v1/itineraries/${snapshot.id}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, env);
+    expect(rePub.status).toBe(403);
+    const json = await rePub.json() as { error: { code: string } };
+    expect(json.error.code).toBe('FORBIDDEN');
+  });
+
+  it('returns 404 for non-existent itinerary', async () => {
+    const res = await app.request('/api/v1/itineraries/nonexistent-id/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
     }, env);
     expect(res.status).toBe(404);
   });

--- a/apps/api/test/itineraries.test.ts
+++ b/apps/api/test/itineraries.test.ts
@@ -229,6 +229,29 @@ describe('Itineraries API', () => {
 
       expect(response.status).toBe(404);
     });
+
+    it('returns 403 when trying to edit a shared snapshot', async () => {
+      const createRes = await app.fetch(new Request('http://localhost/api/v1/itineraries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'オリジナル' }),
+      }), env);
+      const { data: original } = await createRes.json() as any;
+
+      const publishRes = await app.fetch(new Request(`http://localhost/api/v1/itineraries/${original.id}/publish`, {
+        method: 'POST',
+      }), env);
+      const { data: snapshot } = await publishRes.json() as any;
+
+      const updateRes = await app.fetch(new Request(`http://localhost/api/v1/itineraries/${snapshot.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '改ざん' }),
+      }), env);
+      expect(updateRes.status).toBe(403);
+      const { error } = await updateRes.json() as any;
+      expect(error.code).toBe('FORBIDDEN');
+    });
   });
 
   describe('DELETE /api/v1/itineraries/:id', () => {
@@ -260,6 +283,27 @@ describe('Itineraries API', () => {
       const response = await app.fetch(deleteRequest, env);
 
       expect(response.status).toBe(404);
+    });
+
+    it('returns 403 when trying to delete a shared snapshot', async () => {
+      const createRes = await app.fetch(new Request('http://localhost/api/v1/itineraries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'オリジナル' }),
+      }), env);
+      const { data: original } = await createRes.json() as any;
+
+      const publishRes = await app.fetch(new Request(`http://localhost/api/v1/itineraries/${original.id}/publish`, {
+        method: 'POST',
+      }), env);
+      const { data: snapshot } = await publishRes.json() as any;
+
+      const deleteRes = await app.fetch(new Request(`http://localhost/api/v1/itineraries/${snapshot.id}`, {
+        method: 'DELETE',
+      }), env);
+      expect(deleteRes.status).toBe(403);
+      const { error } = await deleteRes.json() as any;
+      expect(error.code).toBe('FORBIDDEN');
     });
   });
 });

--- a/apps/api/test/users-profile.test.ts
+++ b/apps/api/test/users-profile.test.ts
@@ -14,6 +14,7 @@ async function applyMigrations(db: D1Database) {
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_itineraries_source_id ON itineraries(source_itinerary_id) WHERE source_itinerary_id IS NOT NULL;`,
     `CREATE TABLE IF NOT EXISTS steps (
       id TEXT PRIMARY KEY,
       itinerary_id TEXT NOT NULL,

--- a/apps/api/test/users-profile.test.ts
+++ b/apps/api/test/users-profile.test.ts
@@ -10,6 +10,7 @@ async function applyMigrations(db: D1Database) {
       theme_id TEXT NOT NULL DEFAULT 'standard-autumn',
       memo TEXT,
       password TEXT,
+      source_itinerary_id TEXT,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,

--- a/apps/api/test/users-profile.test.ts
+++ b/apps/api/test/users-profile.test.ts
@@ -93,6 +93,26 @@ async function makeVisible(token: string, itineraryId: string): Promise<void> {
   expect(res.status).toBe(200);
 }
 
+// Publish itinerary → sync shared snapshot to bookmarks → make it visible
+// Returns the shared snapshot ID
+async function publishAndMakeVisible(token: string, itineraryId: string): Promise<string> {
+  const publishRes = await app.request(`/api/v1/itineraries/${itineraryId}/publish`, {
+    method: 'POST',
+  }, env);
+  expect(publishRes.status).toBe(200);
+  const publishJson = await publishRes.json() as { data: { id: string } };
+  const sharedId = publishJson.data.id;
+
+  await app.request('/api/v1/users/me/sync-bookmarks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ itinerary_ids: [sharedId] }),
+  }, env);
+
+  await makeVisible(token, sharedId);
+  return sharedId;
+}
+
 describe('PATCH /api/v1/users/me/profile', () => {
   beforeEach(async () => {
     await applyMigrations(env.DB);
@@ -344,7 +364,7 @@ describe('GET /api/v1/users (public feed)', () => {
   it('returns public bookmarks with username', async () => {
     const token = await registerAndGetToken('feeduser', 'feed@example.com');
 
-    // Create itinerary and bookmark it
+    // Create itinerary
     const itinRes = await app.request('/api/v1/itineraries', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
@@ -353,8 +373,8 @@ describe('GET /api/v1/users (public feed)', () => {
     const itinJson = await itinRes.json() as { data: { id: string } };
     const itineraryId = itinJson.data.id;
 
-    // Make bookmark visible (default is now private)
-    await makeVisible(token, itineraryId);
+    // Publish → creates shared snapshot; make it visible so it appears in the feed
+    const sharedId = await publishAndMakeVisible(token, itineraryId);
 
     const res = await app.request('/api/v1/users', {}, env);
     expect(res.status).toBe(200);
@@ -362,7 +382,7 @@ describe('GET /api/v1/users (public feed)', () => {
     expect(json.data.items).toHaveLength(1);
     expect(json.data.items[0].username).toBe('feeduser');
     expect(json.data.items[0].title).toBe('公開しおり');
-    expect(json.data.items[0].itinerary_id).toBe(itineraryId);
+    expect(json.data.items[0].itinerary_id).toBe(sharedId);
   });
 
   it('excludes non-visible bookmarks', async () => {
@@ -398,7 +418,7 @@ describe('GET /api/v1/users (public feed)', () => {
         body: JSON.stringify({ title: `しおり${i}` }),
       }, env);
       const rJson = await r.json() as { data: { id: string } };
-      await makeVisible(token, rJson.data.id);
+      await publishAndMakeVisible(token, rJson.data.id);
     }
 
     const res = await app.request('/api/v1/users', {}, env);
@@ -418,7 +438,7 @@ describe('GET /api/v1/users (public feed)', () => {
         body: JSON.stringify({ title: `しおり${i}` }),
       }, env);
       const rJson = await r.json() as { data: { id: string } };
-      await makeVisible(token, rJson.data.id);
+      await publishAndMakeVisible(token, rJson.data.id);
     }
 
     const res = await app.request('/api/v1/users', {}, env);

--- a/apps/api/test/users-sync.test.ts
+++ b/apps/api/test/users-sync.test.ts
@@ -14,6 +14,7 @@ async function applyMigrations(db: D1Database) {
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_itineraries_source_id ON itineraries(source_itinerary_id) WHERE source_itinerary_id IS NOT NULL;`,
     `CREATE TABLE IF NOT EXISTS steps (
       id TEXT PRIMARY KEY,
       itinerary_id TEXT NOT NULL,

--- a/apps/api/test/users-sync.test.ts
+++ b/apps/api/test/users-sync.test.ts
@@ -10,6 +10,7 @@ async function applyMigrations(db: D1Database) {
       theme_id TEXT NOT NULL DEFAULT 'standard-autumn',
       memo TEXT,
       password TEXT,
+      source_itinerary_id TEXT,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
     );`,

--- a/apps/web/src/lib/api/itinerary.ts
+++ b/apps/web/src/lib/api/itinerary.ts
@@ -1,4 +1,4 @@
-import type { Itinerary, CreateItineraryInput, UpdateItineraryInput, ItineraryResponse, ForkItineraryResponse } from '@tabitabi/types';
+import type { Itinerary, CreateItineraryInput, UpdateItineraryInput, ItineraryResponse, ForkItineraryResponse, PublishItineraryResponse } from '@tabitabi/types';
 import { apiClient } from './client';
 import { userAuth } from '../user-auth';
 
@@ -25,4 +25,7 @@ export const itineraryApi = {
     if (!userToken) throw new Error('Not logged in');
     return apiClient.postWithUserToken<ForkItineraryResponse>(`/itineraries/${id}/fork`, {}, userToken);
   },
+
+  publish: (id: string) =>
+    apiClient.post<PublishItineraryResponse>(`/itineraries/${id}/publish`, {}, id),
 };

--- a/apps/web/src/lib/themes/ai-generated/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/ai-generated/ItineraryView.svelte
@@ -114,7 +114,7 @@
     }
     hasEditPermission = auth.hasEditPermission(itinerary.id);
 
-    if (!hasEditPermission && !itinerary.is_password_protected) {
+    if (!hasEditPermission && !itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       attemptEditModeActivation();
     }
 
@@ -160,8 +160,8 @@
       }
     }
 
-    // パスワード未設定なら即座に編集可能、設定ありなら入力ダイアログ
-    if (!itinerary.is_password_protected) {
+    // パスワード未設定かつ共有スナップショットでなければ即座に編集可能、設定ありなら入力ダイアログ
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/map-only/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/map-only/ItineraryView.svelte
@@ -234,8 +234,8 @@
       }
     }
 
-    // パスワード未設定ならそのまま編集可能、設定ありならダイアログを表示
-    if (!itinerary.is_password_protected) {
+    // パスワード未設定かつ共有スナップショットでなければ編集可能、設定ありならダイアログを表示
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/mapbox-journey/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/mapbox-journey/ItineraryView.svelte
@@ -190,8 +190,8 @@
       }
     }
 
-    // パスワード未設定なら編集可、設定ありなら入力ダイアログ
-    if (!itinerary.is_password_protected) {
+    // パスワード未設定かつ共有スナップショットでなければ編集可、設定ありなら入力ダイアログ
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/minimal/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/minimal/ItineraryView.svelte
@@ -97,7 +97,7 @@
       }
     }
 
-    if (!itinerary.is_password_protected) {
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
       return;

--- a/apps/web/src/lib/themes/pixel-quest/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/pixel-quest/ItineraryView.svelte
@@ -624,7 +624,7 @@
       }
     }
 
-    if (!itinerary.is_password_protected) {
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
       return true;

--- a/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/sauna-rally/ItineraryView.svelte
@@ -139,7 +139,7 @@
       }
     }
 
-    if (!itinerary.is_password_protected) {
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/shopping/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/shopping/ItineraryView.svelte
@@ -119,8 +119,8 @@
       }
     }
 
-    // パスワード未設定なら即編集可、設定ありならダイアログ表示
-    if (!itinerary.is_password_protected) {
+    // パスワード未設定かつ共有スナップショットでなければ即編集可、設定ありならダイアログ表示
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/standard-autumn/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/standard-autumn/ItineraryView.svelte
@@ -111,8 +111,8 @@
     }
     hasEditPermission = auth.hasEditPermission(itinerary.id);
 
-    // パスワード未設定なら即座に編集可、それ以外は手動トグルで実施
-    if (!hasEditPermission && !itinerary.is_password_protected) {
+    // パスワード未設定かつ共有スナップショットでなければ即座に編集可、それ以外は手動トグルで実施
+    if (!hasEditPermission && !itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
     }
 
@@ -164,8 +164,8 @@
       }
     }
 
-    // パスワード不要なら即許可、必要なら入力ダイアログを開く
-    if (!itinerary.is_password_protected) {
+    // パスワード不要かつ共有スナップショットでなければ即許可、必要なら入力ダイアログを開く
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
+++ b/apps/web/src/lib/themes/standard-seasons/shared/ItineraryView.svelte
@@ -145,7 +145,7 @@
     }
     hasEditPermission = auth.hasEditPermission(itinerary.id);
 
-    if (!hasEditPermission && !itinerary.is_password_protected) {
+    if (!hasEditPermission && !itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
     }
 
@@ -209,8 +209,8 @@
       }
     }
 
-    // パスワード不要なら即許可、必要なら入力ダイアログを開く
-    if (!itinerary.is_password_protected) {
+    // パスワード不要かつ共有スナップショットでなければ即許可、必要なら入力ダイアログを開く
+    if (!itinerary.is_password_protected && !itinerary.source_itinerary_id) {
       hasEditPermission = true;
       auth.updateAccessTime(itinerary.id, itinerary.title);
     } else {

--- a/apps/web/src/routes/[id]/+page.svelte
+++ b/apps/web/src/routes/[id]/+page.svelte
@@ -178,6 +178,8 @@
     }
   }
 
+  let isViewOnly = $derived(!!data.itinerary.source_itinerary_id);
+
   let isLoggedIn = $state(false);
   let forking = $state(false);
 
@@ -212,14 +214,14 @@
   <ItineraryView
     {itinerary}
     {steps}
-    onUpdateItinerary={handleUpdateItinerary}
-    onCreateStep={handleCreateStep}
-    onUpdateStep={handleUpdateStep}
-    onDeleteStep={handleDeleteStep}
+    onUpdateItinerary={isViewOnly ? undefined : handleUpdateItinerary}
+    onCreateStep={isViewOnly ? undefined : handleCreateStep}
+    onUpdateStep={isViewOnly ? undefined : handleUpdateStep}
+    onDeleteStep={isViewOnly ? undefined : handleDeleteStep}
   />
 {/key}
 
-{#if isLoggedIn && !data.itinerary.is_password_protected}
+{#if isViewOnly || (isLoggedIn && !data.itinerary.is_password_protected)}
   <div class="fixed bottom-6 right-6 z-50">
     <button
       onclick={handleFork}

--- a/apps/web/src/routes/[id]/+page.svelte
+++ b/apps/web/src/routes/[id]/+page.svelte
@@ -221,7 +221,7 @@
   />
 {/key}
 
-{#if isViewOnly || (isLoggedIn && !data.itinerary.is_password_protected)}
+{#if isViewOnly}
   <div class="fixed bottom-6 right-6 z-50">
     <button
       onclick={handleFork}

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { userApi } from "$lib/api/user";
-  import { itineraryApi } from "$lib/api/itinerary";
   import { userAuth } from "$lib/user-auth";
   import PageShell from "$lib/PageShell.svelte";
   import { auth } from "$lib/auth";
@@ -107,37 +106,6 @@
     email = "";
     password = "";
     goto("/");
-  }
-
-  let publishingId = $state<string | null>(null);
-
-  async function handlePublish(itineraryId: string, isFirstPublish: boolean) {
-    if (publishingId) return;
-    publishingId = itineraryId;
-    try {
-      const result = await itineraryApi.publish(itineraryId);
-      if (isFirstPublish) {
-        // 初回公開のみ: ブックマークに追加して公開状態にする（/users に表示されるようにする）
-        await userApi.syncBookmarks([result.id]);
-        await userApi.updateVisibility(result.id, { is_visible: true });
-      }
-      // ブックマーク一覧を再取得して反映
-      await loadBookmarks();
-    } catch {
-      alert("共有URLの発行に失敗しました");
-    } finally {
-      publishingId = null;
-    }
-  }
-
-  async function copySharedUrl(sharedId: string) {
-    const url = `${window.location.origin}/${sharedId}`;
-    try {
-      await navigator.clipboard.writeText(url);
-      alert("共有URLをコピーしました");
-    } catch {
-      alert(`共有URL: ${url}`);
-    }
   }
 
   async function toggleVisibility(itineraryId: string, current: boolean) {
@@ -512,35 +480,15 @@
                     </span>
                   {/if}
 
-                  {#if !bookmark.source_itinerary_id}
-                    {#if bookmark.shared_itinerary_id}
-                      <button
-                        onclick={() => copySharedUrl(bookmark.shared_itinerary_id!)}
-                        class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
-                      >
-                        共有URLをコピー
-                      </button>
-                      {#if bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
-                        <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
-                          更新あり
-                        </span>
-                      {/if}
-                      <button
-                        onclick={() => handlePublish(bookmark.itinerary_id, false)}
-                        disabled={publishingId === bookmark.itinerary_id}
-                        class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
-                      >
-                        {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
-                      </button>
-                    {:else}
-                      <button
-                        onclick={() => handlePublish(bookmark.itinerary_id, true)}
-                        disabled={publishingId === bookmark.itinerary_id}
-                        class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
-                      >
-                        {publishingId === bookmark.itinerary_id ? "公開中..." : "共有URLを発行"}
-                      </button>
-                    {/if}
+                  {#if bookmark.is_visible && bookmark.shared_itinerary_id}
+                    <a
+                      href="/{bookmark.shared_itinerary_id}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
+                    >
+                      共有URLを見る
+                    </a>
                   {/if}
 
                   <button

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -111,14 +111,16 @@
 
   let publishingId = $state<string | null>(null);
 
-  async function handlePublish(itineraryId: string) {
+  async function handlePublish(itineraryId: string, isFirstPublish: boolean) {
     if (publishingId) return;
     publishingId = itineraryId;
     try {
       const result = await itineraryApi.publish(itineraryId);
-      // ブックマークに追加して公開状態にする（/users に表示されるようにする）
-      await userApi.syncBookmarks([result.id]);
-      await userApi.updateVisibility(result.id, { is_visible: true });
+      if (isFirstPublish) {
+        // 初回公開のみ: ブックマークに追加して公開状態にする（/users に表示されるようにする）
+        await userApi.syncBookmarks([result.id]);
+        await userApi.updateVisibility(result.id, { is_visible: true });
+      }
       // ブックマーク一覧を再取得して反映
       await loadBookmarks();
     } catch {
@@ -524,7 +526,7 @@
                         </span>
                       {/if}
                       <button
-                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        onclick={() => handlePublish(bookmark.itinerary_id, false)}
                         disabled={publishingId === bookmark.itinerary_id}
                         class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
                       >
@@ -532,7 +534,7 @@
                       </button>
                     {:else}
                       <button
-                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        onclick={() => handlePublish(bookmark.itinerary_id, true)}
                         disabled={publishingId === bookmark.itinerary_id}
                         class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
                       >

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { userApi } from "$lib/api/user";
+  import { itineraryApi } from "$lib/api/itinerary";
   import { userAuth } from "$lib/user-auth";
   import PageShell from "$lib/PageShell.svelte";
   import { auth } from "$lib/auth";
@@ -106,6 +107,33 @@
     email = "";
     password = "";
     goto("/");
+  }
+
+  let publishingId = $state<string | null>(null);
+
+  async function handlePublish(itineraryId: string) {
+    if (publishingId) return;
+    publishingId = itineraryId;
+    try {
+      const result = await itineraryApi.publish(itineraryId);
+      bookmarks = bookmarks.map((b) =>
+        b.itinerary_id === itineraryId ? { ...b, shared_itinerary_id: result.id } : b
+      );
+    } catch {
+      alert("共有URLの発行に失敗しました");
+    } finally {
+      publishingId = null;
+    }
+  }
+
+  async function copySharedUrl(sharedId: string) {
+    const url = `${window.location.origin}/${sharedId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      alert("共有URLをコピーしました");
+    } catch {
+      alert(`共有URL: ${url}`);
+    }
   }
 
   async function toggleVisibility(itineraryId: string, current: boolean) {
@@ -470,7 +498,7 @@
                   <p class="text-xs text-gray-400 mt-0.5">{formatDate(bookmark.created_at)}</p>
                 </div>
 
-                <div class="flex items-center gap-3 ml-4 flex-shrink-0">
+                <div class="flex items-center gap-2 ml-4 flex-shrink-0 flex-wrap justify-end">
                   {#if bookmark.is_password_protected}
                     <span class="text-xs text-gray-400 flex items-center gap-1">
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
@@ -478,6 +506,32 @@
                       </svg>
                       鍵あり
                     </span>
+                  {/if}
+
+                  {#if !bookmark.source_itinerary_id}
+                    {#if bookmark.shared_itinerary_id}
+                      <button
+                        onclick={() => copySharedUrl(bookmark.shared_itinerary_id!)}
+                        class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
+                      >
+                        共有URLをコピー
+                      </button>
+                      <button
+                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        disabled={publishingId === bookmark.itinerary_id}
+                        class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+                      >
+                        {publishingId === bookmark.itinerary_id ? "更新中..." : "更新"}
+                      </button>
+                    {:else}
+                      <button
+                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        disabled={publishingId === bookmark.itinerary_id}
+                        class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
+                      >
+                        {publishingId === bookmark.itinerary_id ? "公開中..." : "共有URLを発行"}
+                      </button>
+                    {/if}
                   {/if}
 
                   <button

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -480,17 +480,6 @@
                     </span>
                   {/if}
 
-                  {#if bookmark.is_visible && bookmark.shared_itinerary_id}
-                    <a
-                      href="/{bookmark.shared_itinerary_id}"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
-                    >
-                      共有URLを見る
-                    </a>
-                  {/if}
-
                   <button
                     onclick={() => toggleVisibility(bookmark.itinerary_id, bookmark.is_visible)}
                     class="text-xs px-2 py-1 rounded border transition-colors {bookmark.is_visible

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -116,9 +116,11 @@
     publishingId = itineraryId;
     try {
       const result = await itineraryApi.publish(itineraryId);
-      bookmarks = bookmarks.map((b) =>
-        b.itinerary_id === itineraryId ? { ...b, shared_itinerary_id: result.id } : b
-      );
+      // ブックマークに追加して公開状態にする（/users に表示されるようにする）
+      await userApi.syncBookmarks([result.id]);
+      await userApi.updateVisibility(result.id, { is_visible: true });
+      // ブックマーク一覧を再取得して反映
+      await loadBookmarks();
     } catch {
       alert("共有URLの発行に失敗しました");
     } finally {

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -518,12 +518,17 @@
                       >
                         共有URLをコピー
                       </button>
+                      {#if bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
+                        <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
+                          更新あり
+                        </span>
+                      {/if}
                       <button
                         onclick={() => handlePublish(bookmark.itinerary_id)}
                         disabled={publishingId === bookmark.itinerary_id}
                         class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
                       >
-                        {publishingId === bookmark.itinerary_id ? "更新中..." : "更新"}
+                        {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
                       </button>
                     {:else}
                       <button

--- a/packages/types/src/itinerary.ts
+++ b/packages/types/src/itinerary.ts
@@ -12,6 +12,7 @@ export interface Itinerary {
   password?: string | null;
   secret_settings?: ItinerarySecretSettings | null;
   fork_count?: number;
+  source_itinerary_id?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -21,6 +22,10 @@ export interface ForkItineraryResponse {
   title: string;
   theme_id: string;
   token: string;
+}
+
+export interface PublishItineraryResponse {
+  id: string;
 }
 
 // フロントエンドに返すItinerary（パスワード情報は除外、保護フラグを追加）

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -24,6 +24,8 @@ export interface UserBookmarkWithItinerary extends UserBookmark {
   title: string;
   theme_id: string;
   is_password_protected: boolean;
+  source_itinerary_id?: string | null;
+  shared_itinerary_id?: string | null;
 }
 
 export interface PublicBookmark {

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -24,8 +24,10 @@ export interface UserBookmarkWithItinerary extends UserBookmark {
   title: string;
   theme_id: string;
   is_password_protected: boolean;
+  itinerary_updated_at: string;
   source_itinerary_id?: string | null;
   shared_itinerary_id?: string | null;
+  shared_updated_at?: string | null;
 }
 
 export interface PublicBookmark {


### PR DESCRIPTION
## Summary

- **共有スナップショット自動生成**: ブックマークを「公開」にした瞬間に、共有スナップショットが自動生成される。オーナーが手動で発行操作する必要はない
- **マイページ**: しおり一覧 + 公開/非公開トグル。公開中の場合は「共有URLを見る」リンクを表示するだけ
- **/users & /users/:username**: 共有スナップショット（`source_itinerary_id IS NOT NULL`）のみ公開表示
- **フォークボタン**: 共有スナップショットページのみ表示。元しおりページには出さない
- **セキュリティ**: `PUT /:id` / `DELETE /:id` でスナップショットへの不正な編集・削除を 403 で拒否

## 仕様詳細

### 公開フロー

```
元のしおり
  └─ オーナーがブックマークを「公開」に変更
       └─ 共有スナップショット自動生成（password = NULL, source_itinerary_id = 元のID）
            ├─ /users・/users/:username に表示される
            ├─ 閲覧のみ（編集UI非表示）
            └─ 誰でもフォーク可
                 └─ フォーク先（password = NULL）→ フォークしたユーザーが自由に編集可
```

- 元のしおりにパスワードがあっても、共有スナップショットは常に `password = NULL`
- フォーク先もパスワードなし（自分用コピーとして自由編集できるのが意図通り）
- 一度公開したスナップショットはオーナーが個別に削除・更新する手段はない（`PUT`/`DELETE` は 403）

### マイページ上の表示

| 状態 | 表示 |
|---|---|
| 非公開 | 公開/非公開トグルのみ |
| 公開済み | 「共有URLを見る」リンク ＋ 公開/非公開トグル |

## Changes

### API
- `migrations/0015_add_source_itinerary_id.sql`: `source_itinerary_id` カラムと UNIQUE partial index を追加
- `itinerary.service.ts`: `publish()` メソッド（冪等: CREATE or UPDATE）、concurrent publish race condition 対応
- `user.service.ts`: `getMyBookmarks` に `source_itinerary_id IS NULL` フィルタ・`itinerary_updated_at`・`shared_updated_at` を追加。`getPublicBookmarks`・`getPublicFeed` に `source_itinerary_id IS NOT NULL` フィルタを追加
- `routes/users.ts`: visibility を `true` にしたとき共有スナップショットを自動生成
- `routes/itineraries.ts`: `POST /:id/publish` エンドポイント追加、`PUT`/`DELETE` でスナップショット保護ガード追加

### Frontend
- `routes/profile/+page.svelte`: 発行系ボタン削除。公開中の場合は「共有URLを見る」リンクのみ
- `routes/[id]/+page.svelte`: フォークボタンをスナップショットページのみに限定
- 全 9 テーマの `hasEditPermission` に `source_itinerary_id` チェックを追加

## Test plan

- [ ] ブックマークを「公開」にする → 共有スナップショットが自動生成され `/users` に表示される
- [ ] マイページに「共有URLを見る」リンクが表示される
- [ ] 共有スナップショットページで編集UIが非表示・フォークボタンは表示される
- [ ] 元のしおりページでフォークボタンが表示されない
- [ ] フォーク先はパスワードなしで自由に編集できる
- [ ] 共有スナップショットへの PUT/DELETE → 403
- [ ] `pnpm test` で全 80 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)