### PR TITLE
feat(share): 共有スナップショットの最新化ボタン復元・鍵付き公開対応 (SOR-23, SOR-24)

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -210,20 +210,30 @@ users.patch('/me/bookmarks/:itineraryId/visibility', userAuthMiddleware, async (
     return c.json({ success: false, error: { code: 'NOT_FOUND', message: 'Bookmark not found' } }, 404);
   }
 
-  // 公開にした場合、パスワードなしのしおりのみ共有スナップショットを自動生成する
-  // パスワード付きしおりはしおりトークンが必要なため、ここでは自動生成しない
-  if (input.is_visible) {
-    try {
-      const itineraryService = new ItineraryService(c.env.DB);
-      const itinerary = await itineraryService.get(itineraryId);
-      if (itinerary && !itinerary.password) {
+  // スナップショットの公開状態を元しおりと連動させる
+  try {
+    const itineraryService = new ItineraryService(c.env.DB);
+    const itinerary = await itineraryService.get(itineraryId);
+    if (itinerary) {
+      if (input.is_visible) {
+        // 公開にした場合、共有スナップショットを自動生成する
+        // スナップショットの password は常に NULL なので鍵付きしおりでも安全
         const snapshot = await itineraryService.publish(itineraryId);
         await service.syncBookmarks(userId, [snapshot.id]);
         await service.updateBookmarkVisibility(userId, snapshot.id, true);
+      } else {
+        // 非公開にした場合、スナップショットのブックマークも非公開にする
+        const snapshotRow = await c.env.DB
+          .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
+          .bind(itineraryId)
+          .first<{ id: string }>();
+        if (snapshotRow) {
+          await service.updateBookmarkVisibility(userId, snapshotRow.id, false);
+        }
       }
-    } catch {
-      // 非致命的: 元しおりの公開状態は変更済み、スナップショット生成は後から同期可能
     }
+  } catch {
+    // 非致命的: 元しおりの公開状態は変更済み、スナップショット連動は後から同期可能
   }
 
   return c.json({ success: true, data: result });

--- a/apps/api/test/users-sync.test.ts
+++ b/apps/api/test/users-sync.test.ts
@@ -226,3 +226,116 @@ describe('POST /api/v1/itineraries with user token', () => {
     expect(res.status).toBe(201);
   });
 });
+
+describe('PATCH /api/v1/users/me/bookmarks/:itineraryId/visibility — snapshot sync', () => {
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM user_bookmarks').run();
+    await env.DB.prepare('DELETE FROM users').run();
+    await env.DB.prepare('DELETE FROM steps').run();
+    await env.DB.prepare('DELETE FROM itineraries').run();
+  });
+
+  it('creates snapshot and marks it visible when toggling visibility to true', async () => {
+    const token = await registerAndGetToken('visuser', 'vis@example.com');
+    const itineraryId = await createItinerary();
+
+    // sync bookmark first
+    await app.request('/api/v1/users/me/sync-bookmarks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ itinerary_ids: [itineraryId] }),
+    }, env);
+
+    // toggle visibility to true
+    const res = await app.request(`/api/v1/users/me/bookmarks/${itineraryId}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ is_visible: true }),
+    }, env);
+    expect(res.status).toBe(200);
+
+    // verify snapshot was created
+    const snapshot = await env.DB
+      .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
+      .bind(itineraryId)
+      .first<{ id: string }>();
+    expect(snapshot).not.toBeNull();
+
+    // verify snapshot bookmark is visible
+    const snapshotBookmark = await env.DB
+      .prepare('SELECT is_visible FROM user_bookmarks WHERE itinerary_id = ?')
+      .bind(snapshot!.id)
+      .first<{ is_visible: number }>();
+    expect(snapshotBookmark).not.toBeNull();
+    expect(snapshotBookmark!.is_visible).toBe(1);
+  });
+
+  it('hides snapshot bookmark when toggling visibility to false', async () => {
+    const token = await registerAndGetToken('hideuser', 'hide@example.com');
+    const itineraryId = await createItinerary();
+
+    // sync and publish
+    await app.request('/api/v1/users/me/sync-bookmarks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ itinerary_ids: [itineraryId] }),
+    }, env);
+    await app.request(`/api/v1/users/me/bookmarks/${itineraryId}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ is_visible: true }),
+    }, env);
+
+    // toggle visibility to false
+    const res = await app.request(`/api/v1/users/me/bookmarks/${itineraryId}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ is_visible: false }),
+    }, env);
+    expect(res.status).toBe(200);
+
+    // verify snapshot bookmark is now hidden
+    const snapshot = await env.DB
+      .prepare('SELECT id FROM itineraries WHERE source_itinerary_id = ?')
+      .bind(itineraryId)
+      .first<{ id: string }>();
+    expect(snapshot).not.toBeNull();
+
+    const snapshotBookmark = await env.DB
+      .prepare('SELECT is_visible FROM user_bookmarks WHERE itinerary_id = ?')
+      .bind(snapshot!.id)
+      .first<{ is_visible: number }>();
+    expect(snapshotBookmark).not.toBeNull();
+    expect(snapshotBookmark!.is_visible).toBe(0);
+  });
+
+  it('creates snapshot for password-protected itinerary when toggling visibility to true', async () => {
+    const token = await registerAndGetToken('pwuser', 'pw@example.com');
+
+    // create password-protected itinerary
+    const createRes = await app.request('/api/v1/itineraries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ title: '鍵付きしおり', password: 'secret123' }),
+    }, env);
+    const createJson = await createRes.json() as { data: { id: string } };
+    const itineraryId = createJson.data.id;
+
+    // toggle visibility to true
+    const res = await app.request(`/api/v1/users/me/bookmarks/${itineraryId}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ is_visible: true }),
+    }, env);
+    expect(res.status).toBe(200);
+
+    // verify snapshot was created (even for password-protected itinerary)
+    const snapshot = await env.DB
+      .prepare('SELECT id, password FROM itineraries WHERE source_itinerary_id = ?')
+      .bind(itineraryId)
+      .first<{ id: string; password: string | null }>();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.password).toBeNull(); // snapshot has no password
+  });
+});

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
   import { userApi } from "$lib/api/user";
+  import { itineraryApi } from "$lib/api/itinerary";
   import { userAuth } from "$lib/user-auth";
   import PageShell from "$lib/PageShell.svelte";
   import { auth } from "$lib/auth";
@@ -106,6 +107,35 @@
     email = "";
     password = "";
     goto("/");
+  }
+
+  let publishingId = $state<string | null>(null);
+
+  async function handlePublish(itineraryId: string) {
+    if (publishingId) return;
+    publishingId = itineraryId;
+    try {
+      const result = await itineraryApi.publish(itineraryId);
+      // ブックマークに追加して公開状態にする（/users に表示されるようにする）
+      await userApi.syncBookmarks([result.id]);
+      await userApi.updateVisibility(result.id, { is_visible: true });
+      // ブックマーク一覧を再取得して反映
+      await loadBookmarks();
+    } catch {
+      alert("共有URLの発行に失敗しました");
+    } finally {
+      publishingId = null;
+    }
+  }
+
+  async function copySharedUrl(sharedId: string) {
+    const url = `${window.location.origin}/${sharedId}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      alert("共有URLをコピーしました");
+    } catch {
+      alert(`共有URL: ${url}`);
+    }
   }
 
   async function toggleVisibility(itineraryId: string, current: boolean) {
@@ -478,6 +508,37 @@
                       </svg>
                       鍵あり
                     </span>
+                  {/if}
+
+                  {#if !bookmark.source_itinerary_id}
+                    {#if bookmark.shared_itinerary_id}
+                      <button
+                        onclick={() => copySharedUrl(bookmark.shared_itinerary_id!)}
+                        class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
+                      >
+                        共有URLをコピー
+                      </button>
+                      {#if bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
+                        <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
+                          更新あり
+                        </span>
+                      {/if}
+                      <button
+                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        disabled={publishingId === bookmark.itinerary_id}
+                        class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+                      >
+                        {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
+                      </button>
+                    {:else}
+                      <button
+                        onclick={() => handlePublish(bookmark.itinerary_id)}
+                        disabled={publishingId === bookmark.itinerary_id}
+                        class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
+                      >
+                        {publishingId === bookmark.itinerary_id ? "公開中..." : "共有URLを発行"}
+                      </button>
+                    {/if}
                   {/if}
 
                   <button

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -109,18 +109,18 @@
     goto("/");
   }
 
-  let publishingId = $state<string | null>(null);
+  let publishingIds = $state(new Set<string>());
 
   async function handleRepublish(itineraryId: string) {
-    if (publishingId === itineraryId) return;
-    publishingId = itineraryId;
+    if (publishingIds.has(itineraryId)) return;
+    publishingIds = new Set([...publishingIds, itineraryId]);
     try {
       await itineraryApi.publish(itineraryId);
       await loadBookmarks();
     } catch {
       alert("最新版の公開に失敗しました");
     } finally {
-      publishingId = null;
+      publishingIds = new Set([...publishingIds].filter(id => id !== itineraryId));
     }
   }
 
@@ -496,16 +496,16 @@
                     </span>
                   {/if}
 
-                  {#if !bookmark.source_itinerary_id && bookmark.shared_itinerary_id && bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
+                  {#if bookmark.is_visible && !bookmark.source_itinerary_id && bookmark.shared_itinerary_id && bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
                     <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
                       更新あり
                     </span>
                     <button
                       onclick={() => handleRepublish(bookmark.itinerary_id)}
-                      disabled={publishingId === bookmark.itinerary_id}
+                      disabled={publishingIds.has(bookmark.itinerary_id)}
                       class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
                     >
-                      {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
+                      {publishingIds.has(bookmark.itinerary_id) ? "公開中..." : "最新版を公開"}
                     </button>
                   {/if}
 

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -112,7 +112,7 @@
   let publishingId = $state<string | null>(null);
 
   async function handlePublish(itineraryId: string) {
-    if (publishingId) return;
+    if (publishingId === itineraryId) return;
     publishingId = itineraryId;
     try {
       const result = await itineraryApi.publish(itineraryId);

--- a/apps/web/src/routes/profile/+page.svelte
+++ b/apps/web/src/routes/profile/+page.svelte
@@ -111,30 +111,16 @@
 
   let publishingId = $state<string | null>(null);
 
-  async function handlePublish(itineraryId: string) {
+  async function handleRepublish(itineraryId: string) {
     if (publishingId === itineraryId) return;
     publishingId = itineraryId;
     try {
-      const result = await itineraryApi.publish(itineraryId);
-      // ブックマークに追加して公開状態にする（/users に表示されるようにする）
-      await userApi.syncBookmarks([result.id]);
-      await userApi.updateVisibility(result.id, { is_visible: true });
-      // ブックマーク一覧を再取得して反映
+      await itineraryApi.publish(itineraryId);
       await loadBookmarks();
     } catch {
-      alert("共有URLの発行に失敗しました");
+      alert("最新版の公開に失敗しました");
     } finally {
       publishingId = null;
-    }
-  }
-
-  async function copySharedUrl(sharedId: string) {
-    const url = `${window.location.origin}/${sharedId}`;
-    try {
-      await navigator.clipboard.writeText(url);
-      alert("共有URLをコピーしました");
-    } catch {
-      alert(`共有URL: ${url}`);
     }
   }
 
@@ -510,35 +496,17 @@
                     </span>
                   {/if}
 
-                  {#if !bookmark.source_itinerary_id}
-                    {#if bookmark.shared_itinerary_id}
-                      <button
-                        onclick={() => copySharedUrl(bookmark.shared_itinerary_id!)}
-                        class="text-xs px-2 py-1 rounded border border-blue-300 text-blue-700 bg-blue-50 hover:bg-blue-100 transition-colors"
-                      >
-                        共有URLをコピー
-                      </button>
-                      {#if bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
-                        <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
-                          更新あり
-                        </span>
-                      {/if}
-                      <button
-                        onclick={() => handlePublish(bookmark.itinerary_id)}
-                        disabled={publishingId === bookmark.itinerary_id}
-                        class="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 disabled:opacity-50 transition-colors"
-                      >
-                        {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
-                      </button>
-                    {:else}
-                      <button
-                        onclick={() => handlePublish(bookmark.itinerary_id)}
-                        disabled={publishingId === bookmark.itinerary_id}
-                        class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
-                      >
-                        {publishingId === bookmark.itinerary_id ? "公開中..." : "共有URLを発行"}
-                      </button>
-                    {/if}
+                  {#if !bookmark.source_itinerary_id && bookmark.shared_itinerary_id && bookmark.shared_updated_at && bookmark.itinerary_updated_at > bookmark.shared_updated_at}
+                    <span class="text-xs px-2 py-1 rounded bg-amber-100 text-amber-700 border border-amber-300">
+                      更新あり
+                    </span>
+                    <button
+                      onclick={() => handleRepublish(bookmark.itinerary_id)}
+                      disabled={publishingId === bookmark.itinerary_id}
+                      class="text-xs px-2 py-1 rounded border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 disabled:opacity-50 transition-colors"
+                    >
+                      {publishingId === bookmark.itinerary_id ? "公開中..." : "最新版を公開"}
+                    </button>
                   {/if}
 
                   <button


### PR DESCRIPTION
## Summary
- マイページから誤って削除されていた「更新あり」バッジと「最新版を公開」ボタンを復元 (SOR-23)
- 鍵付きしおりでも公開トグルでスナップショットが自動生成されるよう修正 (SOR-24)
- 非公開にした際、スナップショットのブックマークも連動して非公開にする

## Test plan
- [ ] マイページでしおりを公開→スナップショットが自動生成される
- [ ] 鍵付きしおりでも公開→スナップショットが生成される
- [ ] 公開済みしおりを編集→「更新あり」バッジが表示される
- [ ] 「最新版を公開」ボタン押下→スナップショットが最新化されバッジが消える
- [ ] 非公開にする→公開フィード(/users/)からスナップショットが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)