### PR TITLE
feat(api): zod-validator による入力バリデーション強化 (SOR-16)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,9 +11,11 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.7.6",
     "@tsndr/cloudflare-worker-jwt": "^3.2.0",
     "bcryptjs": "^2.4.3",
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.10.10",

--- a/apps/api/src/routes/itineraries.ts
+++ b/apps/api/src/routes/itineraries.ts
@@ -1,9 +1,12 @@
 import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
 import { Env, Variables } from '../utils';
 import { ItineraryService } from '../services/itinerary.service';
 import { authMiddleware, optionalAuthMiddleware, optionalUserAuthMiddleware, userAuthMiddleware } from '../middleware/auth';
 import { generateToken } from '../utils/jwt';
 import { UserService } from '../services/user.service';
+import { createItinerarySchema, updateItinerarySchema } from '../validators';
+import { validationHook } from '../validators/hook';
 
 const itineraries = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -26,8 +29,8 @@ itineraries.get('/:id', async (c) => {
   return c.json({ success: true, data: service.toResponseItinerary(data) });
 });
 
-itineraries.post('/', optionalUserAuthMiddleware, async (c) => {
-  const input = await c.req.json();
+itineraries.post('/', optionalUserAuthMiddleware, zValidator('json', createItinerarySchema, validationHook), async (c) => {
+  const input = c.req.valid('json');
   const service = new ItineraryService(c.env.DB);
   const data = await service.create(input);
 
@@ -47,9 +50,9 @@ itineraries.post('/', optionalUserAuthMiddleware, async (c) => {
   return c.json({ success: true, data: { ...response, token } }, 201);
 });
 
-itineraries.put('/:id', optionalAuthMiddleware, async (c) => {
+itineraries.put('/:id', optionalAuthMiddleware, zValidator('json', updateItinerarySchema, validationHook), async (c) => {
   const id = c.req.param('id');
-  const input = await c.req.json();
+  const input = c.req.valid('json');
   const service = new ItineraryService(c.env.DB);
   const existing = await service.get(id);
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -5,9 +5,8 @@ import { UserService } from '../services/user.service';
 import { ItineraryService } from '../services/itinerary.service';
 import { userAuthMiddleware } from '../middleware/auth';
 import { generateUserToken } from '../utils/jwt';
-import { registerSchema, loginSchema, syncBookmarksSchema } from '../validators';
+import { registerSchema, loginSchema, syncBookmarksSchema, updateProfileSchema, updatePasswordSchema, updateVisibilitySchema } from '../validators';
 import { validationHook } from '../validators/hook';
-import type { UpdateVisibilityInput, UpdateProfileInput, UpdatePasswordInput } from '@tabitabi/types';
 
 const users = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -62,7 +61,7 @@ users.get('/search', async (c) => {
     return c.json({ success: true, data: { users: [] } });
   }
   if (trimmedQ.length > 50) {
-    return c.json({ success: false, error: { code: 'INVALID_INPUT', message: 'q must be 50 characters or less' } }, 400);
+    return c.json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'q must be 50 characters or less' } }, 400);
   }
 
   const service = new UserService(c.env.DB);
@@ -83,20 +82,9 @@ users.get('/', async (c) => {
 
 // ※ 静的ルート (/me/...) は動的ルート (/:username/...) より先に登録すること
 // PATCH /users/me/profile (認証必須 - プロフィール更新)
-users.patch('/me/profile', userAuthMiddleware, async (c) => {
+users.patch('/me/profile', userAuthMiddleware, zValidator('json', updateProfileSchema, validationHook), async (c) => {
   const userId = c.get('userId')!;
-  const input: UpdateProfileInput = await c.req.json();
-
-  const usernameProvided = typeof input.username === 'string';
-  const emailProvided = typeof input.email === 'string';
-
-  if (!usernameProvided && !emailProvided) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'username or email is required' }
-    }, 400);
-  }
-
+  const input = c.req.valid('json');
   const service = new UserService(c.env.DB);
 
   try {
@@ -113,17 +101,9 @@ users.patch('/me/profile', userAuthMiddleware, async (c) => {
 });
 
 // PATCH /users/me/password (認証必須 - パスワード変更)
-users.patch('/me/password', userAuthMiddleware, async (c) => {
+users.patch('/me/password', userAuthMiddleware, zValidator('json', updatePasswordSchema, validationHook), async (c) => {
   const userId = c.get('userId')!;
-  const input: UpdatePasswordInput = await c.req.json();
-
-  if (typeof input.current_password !== 'string' || typeof input.new_password !== 'string' || !input.current_password || !input.new_password) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'current_password and new_password are required' }
-    }, 400);
-  }
-
+  const input = c.req.valid('json');
   const service = new UserService(c.env.DB);
 
   try {
@@ -157,18 +137,10 @@ users.get('/me/bookmarks', userAuthMiddleware, async (c) => {
 });
 
 // PATCH /users/me/bookmarks/:itineraryId/visibility (認証必須)
-users.patch('/me/bookmarks/:itineraryId/visibility', userAuthMiddleware, async (c) => {
+users.patch('/me/bookmarks/:itineraryId/visibility', userAuthMiddleware, zValidator('json', updateVisibilitySchema, validationHook), async (c) => {
   const userId = c.get('userId')!;
   const itineraryId = c.req.param('itineraryId');
-  const input: UpdateVisibilityInput = await c.req.json();
-
-  if (typeof input.is_visible !== 'boolean') {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'is_visible must be a boolean' }
-    }, 400);
-  }
-
+  const input = c.req.valid('json');
   const service = new UserService(c.env.DB);
   const result = await service.updateBookmarkVisibility(userId, itineraryId, input.is_visible);
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,24 +1,19 @@
 import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
 import { Env, Variables } from '../utils';
 import { UserService } from '../services/user.service';
 import { ItineraryService } from '../services/itinerary.service';
 import { userAuthMiddleware } from '../middleware/auth';
 import { generateUserToken } from '../utils/jwt';
-import type { RegisterInput, LoginInput, UpdateVisibilityInput, SyncBookmarksInput, UpdateProfileInput, UpdatePasswordInput } from '@tabitabi/types';
+import { registerSchema, loginSchema, syncBookmarksSchema } from '../validators';
+import { validationHook } from '../validators/hook';
+import type { UpdateVisibilityInput, UpdateProfileInput, UpdatePasswordInput } from '@tabitabi/types';
 
 const users = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 // POST /users/register
-users.post('/register', async (c) => {
-  const input: RegisterInput = await c.req.json();
-
-  if (!input.username || !input.email || !input.password) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'username, email, password are required' }
-    }, 400);
-  }
-
+users.post('/register', zValidator('json', registerSchema, validationHook), async (c) => {
+  const input = c.req.valid('json');
   const service = new UserService(c.env.DB);
 
   try {
@@ -39,16 +34,8 @@ users.post('/register', async (c) => {
 });
 
 // POST /users/login
-users.post('/login', async (c) => {
-  const input: LoginInput = await c.req.json();
-
-  if (!input.email || !input.password) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'email and password are required' }
-    }, 400);
-  }
-
+users.post('/login', zValidator('json', loginSchema, validationHook), async (c) => {
+  const input = c.req.valid('json');
   const service = new UserService(c.env.DB);
 
   try {
@@ -152,30 +139,9 @@ users.patch('/me/password', userAuthMiddleware, async (c) => {
 });
 
 // POST /users/me/sync-bookmarks (認証必須 - ログイン時の localStorage→server 同期)
-users.post('/me/sync-bookmarks', userAuthMiddleware, async (c) => {
+users.post('/me/sync-bookmarks', userAuthMiddleware, zValidator('json', syncBookmarksSchema, validationHook), async (c) => {
   const userId = c.get('userId')!;
-  const input: SyncBookmarksInput = await c.req.json();
-
-  if (!Array.isArray(input.itinerary_ids)) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'itinerary_ids must be an array' }
-    }, 400);
-  }
-
-  if (input.itinerary_ids.length > 50) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'Too many itinerary_ids (max 50)' }
-    }, 400);
-  }
-
-  if (!input.itinerary_ids.every((id) => typeof id === 'string' && id.length > 0)) {
-    return c.json({
-      success: false,
-      error: { code: 'INVALID_INPUT', message: 'itinerary_ids must contain only non-empty strings' }
-    }, 400);
-  }
+  const input = c.req.valid('json');
 
   const service = new UserService(c.env.DB);
   const result = await service.syncBookmarks(userId, input.itinerary_ids);

--- a/apps/api/src/validators/hook.ts
+++ b/apps/api/src/validators/hook.ts
@@ -1,0 +1,19 @@
+import type { Context } from 'hono';
+
+/**
+ * zValidator の hook: バリデーション失敗時に統一エラーレスポンスを返す
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validationHook(result: { success: boolean; error?: any }, c: Context) {
+  if (!result.success) {
+    const issues = result.error?.issues ?? [];
+    const message = issues.map((i: { path: PropertyKey[]; message: string }) => {
+      const path = i.path.map(String).join('.');
+      return path ? `${path}: ${i.message}` : i.message;
+    }).join(', ');
+    return c.json({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message },
+    }, 400);
+  }
+}

--- a/apps/api/src/validators/index.ts
+++ b/apps/api/src/validators/index.ts
@@ -51,11 +51,40 @@ export const updateItinerarySchema = z.object({
   theme_id: z.string().optional(),
   memo: z.string().optional(),
   walica_id: z.string().nullable().optional(),
-  password: z.string().optional(),
+  password: z.string().min(1, 'password must not be empty').optional(),
   secret_settings: z.object({
     enabled: z.boolean(),
     offset_minutes: z.number(),
   }).nullable().optional(),
+});
+
+// ── Profile / Password ─────────────────────────────────
+
+export const updateProfileSchema = z.object({
+  username: z
+    .string()
+    .min(3, 'username must be at least 3 characters')
+    .max(20, 'username must be at most 20 characters')
+    .optional(),
+  email: z
+    .string()
+    .email('invalid email format')
+    .optional(),
+}).refine(data => data.username !== undefined || data.email !== undefined, {
+  message: 'username or email is required',
+});
+
+export const updatePasswordSchema = z.object({
+  current_password: z
+    .string({ error: 'current_password is required' })
+    .min(1, 'current_password is required'),
+  new_password: z
+    .string({ error: 'new_password is required' })
+    .min(8, 'new_password must be at least 8 characters'),
+});
+
+export const updateVisibilitySchema = z.object({
+  is_visible: z.boolean({ error: 'is_visible must be a boolean' }),
 });
 
 // ── Bookmarks ──────────────────────────────────────────

--- a/apps/api/src/validators/index.ts
+++ b/apps/api/src/validators/index.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+// ── Users ──────────────────────────────────────────────
+
+export const registerSchema = z.object({
+  username: z
+    .string({ error: 'username is required' })
+    .min(3, 'username must be at least 3 characters')
+    .max(20, 'username must be at most 20 characters')
+    .regex(/^[a-zA-Z0-9_]+$/, 'username must contain only alphanumeric characters and underscores'),
+  email: z
+    .string({ error: 'email is required' })
+    .email('invalid email format'),
+  password: z
+    .string({ error: 'password is required' })
+    .min(8, 'password must be at least 8 characters'),
+});
+
+export const loginSchema = z.object({
+  email: z
+    .string({ error: 'email is required' })
+    .email('invalid email format'),
+  password: z
+    .string({ error: 'password is required' })
+    .min(1, 'password is required'),
+});
+
+// ── Itineraries ────────────────────────────────────────
+
+export const createItinerarySchema = z.object({
+  title: z
+    .string({ error: 'title is required' })
+    .min(1, 'title is required')
+    .max(100, 'title must be at most 100 characters'),
+  theme_id: z.string().optional(),
+  memo: z.string().optional(),
+  walica_id: z.string().optional(),
+  password: z.string().optional(),
+  secret_settings: z.object({
+    enabled: z.boolean(),
+    offset_minutes: z.number(),
+  }).optional(),
+});
+
+export const updateItinerarySchema = z.object({
+  title: z
+    .string()
+    .min(1, 'title must not be empty')
+    .max(100, 'title must be at most 100 characters')
+    .optional(),
+  theme_id: z.string().optional(),
+  memo: z.string().optional(),
+  walica_id: z.string().nullable().optional(),
+  password: z.string().optional(),
+  secret_settings: z.object({
+    enabled: z.boolean(),
+    offset_minutes: z.number(),
+  }).nullable().optional(),
+});
+
+// ── Bookmarks ──────────────────────────────────────────
+
+export const syncBookmarksSchema = z.object({
+  itinerary_ids: z
+    .array(z.string().min(1, 'itinerary_id must be non-empty'))
+    .max(50, 'too many itinerary_ids (max 50)'),
+});

--- a/apps/api/src/validators/index.ts
+++ b/apps/api/src/validators/index.ts
@@ -51,7 +51,7 @@ export const updateItinerarySchema = z.object({
   theme_id: z.string().optional(),
   memo: z.string().optional(),
   walica_id: z.string().nullable().optional(),
-  password: z.string().min(1, 'password must not be empty').optional(),
+  password: z.string().optional(),
   secret_settings: z.object({
     enabled: z.boolean(),
     offset_minutes: z.number(),

--- a/apps/api/test/users-auth.test.ts
+++ b/apps/api/test/users-auth.test.ts
@@ -102,7 +102,7 @@ describe('POST /api/v1/users/register', () => {
     }, env);
     expect(res.status).toBe(400);
     const json = await res.json() as any;
-    expect(json.error.code).toBe('INVALID_INPUT');
+    expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when email is missing', async () => {
@@ -218,7 +218,7 @@ describe('POST /api/v1/users/login', () => {
     }, env);
     expect(res.status).toBe(400);
     const json = await res.json() as any;
-    expect(json.error.code).toBe('INVALID_INPUT');
+    expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when password is missing', async () => {

--- a/apps/api/test/users-profile.test.ts
+++ b/apps/api/test/users-profile.test.ts
@@ -182,7 +182,7 @@ describe('PATCH /api/v1/users/me/profile', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json() as { success: boolean; error: { code: string } };
-    expect(json.error.code).toBe('USERNAME_INVALID_LENGTH');
+    expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 for invalid email format', async () => {
@@ -196,7 +196,7 @@ describe('PATCH /api/v1/users/me/profile', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json() as { success: boolean; error: { code: string } };
-    expect(json.error.code).toBe('EMAIL_INVALID_FORMAT');
+    expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 409 for duplicate username', async () => {
@@ -303,7 +303,7 @@ describe('PATCH /api/v1/users/me/password', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json() as { success: boolean; error: { code: string } };
-    expect(json.error.code).toBe('PASSWORD_TOO_SHORT');
+    expect(json.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when fields are missing', async () => {

--- a/apps/api/test/validation.test.ts
+++ b/apps/api/test/validation.test.ts
@@ -1,0 +1,294 @@
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import app from '../src/index';
+
+async function applyMigrations(db: D1Database) {
+  const migrations = [
+    `CREATE TABLE IF NOT EXISTS itineraries (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      theme_id TEXT NOT NULL DEFAULT 'standard-autumn',
+      memo TEXT,
+      password TEXT,
+      source_itinerary_id TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_itineraries_source_id ON itineraries(source_itinerary_id) WHERE source_itinerary_id IS NOT NULL;`,
+    `CREATE TABLE IF NOT EXISTS steps (
+      id TEXT PRIMARY KEY,
+      itinerary_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      start_at INTEGER NOT NULL,
+      end_at INTEGER NOT NULL,
+      location TEXT,
+      notes TEXT,
+      type TEXT NOT NULL DEFAULT 'normal:general',
+      is_all_day INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (itinerary_id) REFERENCES itineraries(id) ON DELETE CASCADE
+    );`,
+    `CREATE INDEX IF NOT EXISTS idx_steps_itinerary ON steps(itinerary_id);`,
+    `CREATE TABLE IF NOT EXISTS itinerary_secrets (
+      itinerary_id TEXT PRIMARY KEY,
+      enabled BOOLEAN DEFAULT FALSE,
+      offset_minutes INTEGER DEFAULT 60,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (itinerary_id) REFERENCES itineraries(id) ON DELETE CASCADE
+    );`,
+    `CREATE TABLE IF NOT EXISTS itinerary_walica_settings (
+      itinerary_id TEXT PRIMARY KEY,
+      walica_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (itinerary_id) REFERENCES itineraries(id) ON DELETE CASCADE
+    );`,
+    `CREATE TABLE IF NOT EXISTS itinerary_fork_stats (
+      itinerary_id TEXT PRIMARY KEY,
+      fork_count INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY (itinerary_id) REFERENCES itineraries(id) ON DELETE CASCADE
+    );`,
+    `CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      username TEXT UNIQUE NOT NULL,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );`,
+    `CREATE TABLE IF NOT EXISTS user_bookmarks (
+      user_id TEXT NOT NULL,
+      itinerary_id TEXT NOT NULL,
+      is_visible BOOLEAN NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (user_id, itinerary_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (itinerary_id) REFERENCES itineraries(id) ON DELETE CASCADE
+    );`,
+  ];
+  for (const sql of migrations) {
+    await db.prepare(sql).run();
+  }
+}
+
+function jsonPost(path: string, body: unknown, headers?: Record<string, string>) {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  }, env);
+}
+
+function jsonPut(path: string, body: unknown, headers?: Record<string, string>) {
+  return app.request(path, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  }, env);
+}
+
+async function registerAndGetToken(username: string, email: string): Promise<string> {
+  const res = await jsonPost('/api/v1/users/register', { username, email, password: 'password123' });
+  const json = await res.json() as { success: boolean; data: { token: string } };
+  return json.data.token;
+}
+
+async function expectValidationError(res: Response, messageContains?: string) {
+  expect(res.status).toBe(400);
+  const json = await res.json() as any;
+  expect(json.success).toBe(false);
+  expect(json.error.code).toBe('VALIDATION_ERROR');
+  if (messageContains) {
+    expect(json.error.message).toContain(messageContains);
+  }
+}
+
+// ── POST /users/register validation ────────────────────
+
+describe('POST /api/v1/users/register — validation', () => {
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM user_bookmarks').run();
+    await env.DB.prepare('DELETE FROM users').run();
+  });
+
+  it('rejects username shorter than 3 characters', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'ab', email: 'test@example.com', password: 'password123',
+    });
+    await expectValidationError(res, 'username must be at least 3 characters');
+  });
+
+  it('rejects username longer than 20 characters', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'a'.repeat(21), email: 'test@example.com', password: 'password123',
+    });
+    await expectValidationError(res, 'username must be at most 20 characters');
+  });
+
+  it('rejects username with special characters', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'user@name!', email: 'test@example.com', password: 'password123',
+    });
+    await expectValidationError(res, 'alphanumeric');
+  });
+
+  it('accepts username with underscores', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'user_name_1', email: 'test@example.com', password: 'password123',
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects invalid email format', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'testuser', email: 'not-an-email', password: 'password123',
+    });
+    await expectValidationError(res, 'email');
+  });
+
+  it('rejects password shorter than 8 characters', async () => {
+    const res = await jsonPost('/api/v1/users/register', {
+      username: 'testuser', email: 'test@example.com', password: 'short',
+    });
+    await expectValidationError(res, 'password must be at least 8 characters');
+  });
+
+  it('rejects empty body', async () => {
+    const res = await jsonPost('/api/v1/users/register', {});
+    await expectValidationError(res);
+  });
+});
+
+// ── POST /users/login validation ───────────────────────
+
+describe('POST /api/v1/users/login — validation', () => {
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM user_bookmarks').run();
+    await env.DB.prepare('DELETE FROM users').run();
+  });
+
+  it('rejects invalid email format', async () => {
+    const res = await jsonPost('/api/v1/users/login', {
+      email: 'not-an-email', password: 'password123',
+    });
+    await expectValidationError(res, 'email');
+  });
+
+  it('rejects missing email', async () => {
+    const res = await jsonPost('/api/v1/users/login', { password: 'password123' });
+    await expectValidationError(res);
+  });
+
+  it('rejects missing password', async () => {
+    const res = await jsonPost('/api/v1/users/login', { email: 'test@example.com' });
+    await expectValidationError(res);
+  });
+});
+
+// ── POST /itineraries validation ───────────────────────
+
+describe('POST /api/v1/itineraries — validation', () => {
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM steps').run();
+    await env.DB.prepare('DELETE FROM itineraries').run();
+  });
+
+  it('rejects missing title', async () => {
+    const res = await jsonPost('/api/v1/itineraries', {});
+    await expectValidationError(res, 'title');
+  });
+
+  it('rejects empty title', async () => {
+    const res = await jsonPost('/api/v1/itineraries', { title: '' });
+    await expectValidationError(res, 'title');
+  });
+
+  it('rejects title longer than 100 characters', async () => {
+    const res = await jsonPost('/api/v1/itineraries', { title: 'あ'.repeat(101) });
+    await expectValidationError(res, 'title must be at most 100 characters');
+  });
+
+  it('accepts valid title at max length', async () => {
+    const res = await jsonPost('/api/v1/itineraries', { title: 'a'.repeat(100) });
+    expect(res.status).toBe(201);
+  });
+});
+
+// ── PUT /itineraries/:id validation ────────────────────
+
+describe('PUT /api/v1/itineraries/:id — validation', () => {
+  let itineraryId: string;
+
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM steps').run();
+    await env.DB.prepare('DELETE FROM itineraries').run();
+
+    const res = await jsonPost('/api/v1/itineraries', { title: 'テスト旅程' });
+    const json = await res.json() as any;
+    itineraryId = json.data.id;
+  });
+
+  it('rejects empty title', async () => {
+    const res = await jsonPut(`/api/v1/itineraries/${itineraryId}`, { title: '' });
+    await expectValidationError(res, 'title must not be empty');
+  });
+
+  it('rejects title longer than 100 characters', async () => {
+    const res = await jsonPut(`/api/v1/itineraries/${itineraryId}`, { title: 'あ'.repeat(101) });
+    await expectValidationError(res, 'title must be at most 100 characters');
+  });
+
+  it('accepts update without title (partial update)', async () => {
+    const res = await jsonPut(`/api/v1/itineraries/${itineraryId}`, { theme_id: 'pixel-quest' });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── POST /users/me/sync-bookmarks validation ──────────
+
+describe('POST /api/v1/users/me/sync-bookmarks — validation', () => {
+  let token: string;
+
+  beforeEach(async () => {
+    await applyMigrations(env.DB);
+    await env.DB.prepare('DELETE FROM user_bookmarks').run();
+    await env.DB.prepare('DELETE FROM users').run();
+    token = await registerAndGetToken('syncuser', 'sync@example.com');
+  });
+
+  it('rejects non-array itinerary_ids', async () => {
+    const res = await jsonPost('/api/v1/users/me/sync-bookmarks', { itinerary_ids: 'not-array' }, {
+      Authorization: `Bearer ${token}`,
+    });
+    await expectValidationError(res);
+  });
+
+  it('rejects more than 50 itinerary_ids', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `id-${i}`);
+    const res = await jsonPost('/api/v1/users/me/sync-bookmarks', { itinerary_ids: ids }, {
+      Authorization: `Bearer ${token}`,
+    });
+    await expectValidationError(res, 'max 50');
+  });
+
+  it('rejects empty string in itinerary_ids', async () => {
+    const res = await jsonPost('/api/v1/users/me/sync-bookmarks', { itinerary_ids: ['valid', ''] }, {
+      Authorization: `Bearer ${token}`,
+    });
+    await expectValidationError(res);
+  });
+
+  it('accepts empty array', async () => {
+    const res = await jsonPost('/api/v1/users/me/sync-bookmarks', { itinerary_ids: [] }, {
+      Authorization: `Bearer ${token}`,
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@hono/zod-validator':
+        specifier: ^0.7.6
+        version: 0.7.6(hono@4.10.6)(zod@4.3.6)
       '@tsndr/cloudflare-worker-jwt':
         specifier: ^3.2.0
         version: 3.2.0
@@ -35,6 +38,9 @@ importers:
       hono:
         specifier: ^4.6.14
         version: 4.10.6
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.10.10
@@ -970,6 +976,12 @@ packages:
 
   '@googlemaps/js-api-loader@2.0.2':
     resolution: {integrity: sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==}
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3613,6 +3625,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@acemir/cssom@0.9.24': {}
@@ -3696,7 +3711,7 @@ snapshots:
       semver: 7.7.2
       vitest: 3.2.4(@types/node@24.10.1)(jiti@1.21.7)(jsdom@27.2.0)(lightningcss@1.30.1)(tsx@4.21.0)
       wrangler: 4.50.0(@cloudflare/workers-types@4.20250917.0)
-      zod: 3.22.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - bufferutil
@@ -4105,6 +4120,11 @@ snapshots:
   '@googlemaps/js-api-loader@2.0.2':
     dependencies:
       '@types/google.maps': 3.58.1
+
+  '@hono/zod-validator@0.7.6(hono@4.10.6)(zod@4.3.6)':
+    dependencies:
+      hono: 4.10.6
+      zod: 4.3.6
 
   '@img/colour@1.1.0': {}
 
@@ -6918,3 +6938,5 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- `zod` v4 + `@hono/zod-validator` を導入し、users / itineraries ルートの JSON ボディ受付エンドポイントに入力バリデーションを追加
- バリデーションエラーレスポンスを `VALIDATION_ERROR` コードで統一
- 対象エンドポイント:
  - `POST /users/register`: username(3-20文字・英数字_のみ), email形式, password(8文字以上)
  - `POST /users/login`: email形式, password必須
  - `PATCH /users/me/profile`: username(3-20文字), email形式
  - `PATCH /users/me/password`: current_password/new_password必須, new_password(8文字以上)
  - `PATCH /users/me/bookmarks/:id/visibility`: is_visible boolean必須
  - `POST /users/me/sync-bookmarks`: itinerary_ids(配列・最大50件)
  - `POST /itineraries`: title(必須・最大100文字)
  - `PUT /itineraries/:id`: title(空文字不可・最大100文字)
- **Note:** auth.ts, steps.ts, timeline.ts のエンドポイントは今回のスコープ外

## Test plan
- [x] 全バリデーションケースの integration test を追加 (`test/validation.test.ts`)
- [x] 既存テスト 125件すべてパス
- [x] TypeScript 型チェック通過

Closes SOR-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)