### PR TITLE
fix(ci): deploy 時の commit message に SHA のみを渡す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy Web (Pages)
         working-directory: apps/web
-        run: pnpm wrangler pages deploy .svelte-kit/cloudflare --project-name=tabitabi --branch=main
+        run: pnpm wrangler pages deploy .svelte-kit/cloudflare --project-name=tabitabi --branch=main --commit-message="$(git log -1 --format=%H)"


### PR DESCRIPTION
## Summary
- Cloudflare Pages API がコミットメッセージ内の `<script>` 等を XSS フィルタで reject する問題を修正
- `wrangler pages deploy` に `--commit-message` でコミット SHA のみを渡すように変更
- これにより、コミットメッセージの内容に関わらずデプロイが安定する

## Test plan
- [ ] main マージ後の Deploy on main ワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)