### PR TITLE
fix(web): Map API トークンエンドポイントに Origin チェックを追加 (SOR-28)

### DIFF
--- a/apps/web/src/lib/server/validate-origin.test.ts
+++ b/apps/web/src/lib/server/validate-origin.test.ts
@@ -22,14 +22,13 @@ describe('validateOrigin', () => {
   });
 
   it('rejects requests with no Origin or Referer', () => {
-    const req = createRequest({ host: 'example.com' });
+    const req = createRequest();
     expect(() => validateOrigin(req)).toThrow();
   });
 
   it('allows requests with matching Origin (self-origin fallback)', () => {
     const req = createRequest({
       origin: 'https://example.com',
-      host: 'example.com',
     });
     expect(() => validateOrigin(req)).not.toThrow();
   });
@@ -37,7 +36,6 @@ describe('validateOrigin', () => {
   it('rejects requests with mismatched Origin (self-origin fallback)', () => {
     const req = createRequest({
       origin: 'https://evil.com',
-      host: 'example.com',
     });
     expect(() => validateOrigin(req)).toThrow();
   });
@@ -45,7 +43,6 @@ describe('validateOrigin', () => {
   it('allows requests with matching Referer when no Origin', () => {
     const req = createRequest({
       referer: 'https://example.com/page',
-      host: 'example.com',
     });
     expect(() => validateOrigin(req)).not.toThrow();
   });
@@ -53,9 +50,15 @@ describe('validateOrigin', () => {
   it('rejects requests with mismatched Referer', () => {
     const req = createRequest({
       referer: 'https://evil.com/page',
-      host: 'example.com',
     });
     expect(() => validateOrigin(req)).toThrow();
+  });
+
+  it('rejects requests with malformed Referer', () => {
+    for (const referer of ['not-a-url', '/relative/path']) {
+      const req = createRequest({ referer });
+      expect(() => validateOrigin(req)).toThrow();
+    }
   });
 
   describe('ALLOWED_ORIGINS', () => {
@@ -63,7 +66,6 @@ describe('validateOrigin', () => {
       mockEnv.ALLOWED_ORIGINS = 'https://app.example.com, https://staging.example.com';
       const req = createRequest({
         origin: 'https://app.example.com',
-        host: 'example.com',
       });
       expect(() => validateOrigin(req)).not.toThrow();
     });
@@ -72,25 +74,8 @@ describe('validateOrigin', () => {
       mockEnv.ALLOWED_ORIGINS = 'https://app.example.com';
       const req = createRequest({
         origin: 'https://evil.com',
-        host: 'example.com',
       });
       expect(() => validateOrigin(req)).toThrow();
     });
-  });
-
-  it('uses x-forwarded-proto for self-origin comparison', () => {
-    const req = createRequest({
-      origin: 'http://example.com',
-      host: 'example.com',
-      'x-forwarded-proto': 'http',
-    });
-    expect(() => validateOrigin(req)).not.toThrow();
-  });
-
-  it('rejects when host header is missing and no ALLOWED_ORIGINS', () => {
-    const req = createRequest({
-      origin: 'https://example.com',
-    });
-    expect(() => validateOrigin(req)).toThrow();
   });
 });

--- a/apps/web/src/lib/server/validate-origin.test.ts
+++ b/apps/web/src/lib/server/validate-origin.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockEnv } = vi.hoisted(() => {
+  const mockEnv: Record<string, string | undefined> = {};
+  return { mockEnv };
+});
+
+vi.mock('$app/environment', () => ({ dev: false }));
+vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+
+import { validateOrigin } from './validate-origin';
+
+function createRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.com/api/token', { headers });
+}
+
+describe('validateOrigin', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockEnv)) {
+      delete mockEnv[key];
+    }
+  });
+
+  it('rejects requests with no Origin or Referer', () => {
+    const req = createRequest({ host: 'example.com' });
+    expect(() => validateOrigin(req)).toThrow();
+  });
+
+  it('allows requests with matching Origin (self-origin fallback)', () => {
+    const req = createRequest({
+      origin: 'https://example.com',
+      host: 'example.com',
+    });
+    expect(() => validateOrigin(req)).not.toThrow();
+  });
+
+  it('rejects requests with mismatched Origin (self-origin fallback)', () => {
+    const req = createRequest({
+      origin: 'https://evil.com',
+      host: 'example.com',
+    });
+    expect(() => validateOrigin(req)).toThrow();
+  });
+
+  it('allows requests with matching Referer when no Origin', () => {
+    const req = createRequest({
+      referer: 'https://example.com/page',
+      host: 'example.com',
+    });
+    expect(() => validateOrigin(req)).not.toThrow();
+  });
+
+  it('rejects requests with mismatched Referer', () => {
+    const req = createRequest({
+      referer: 'https://evil.com/page',
+      host: 'example.com',
+    });
+    expect(() => validateOrigin(req)).toThrow();
+  });
+
+  describe('ALLOWED_ORIGINS', () => {
+    it('allows origins in the allowlist', () => {
+      mockEnv.ALLOWED_ORIGINS = 'https://app.example.com, https://staging.example.com';
+      const req = createRequest({
+        origin: 'https://app.example.com',
+        host: 'example.com',
+      });
+      expect(() => validateOrigin(req)).not.toThrow();
+    });
+
+    it('rejects origins not in the allowlist', () => {
+      mockEnv.ALLOWED_ORIGINS = 'https://app.example.com';
+      const req = createRequest({
+        origin: 'https://evil.com',
+        host: 'example.com',
+      });
+      expect(() => validateOrigin(req)).toThrow();
+    });
+  });
+
+  it('uses x-forwarded-proto for self-origin comparison', () => {
+    const req = createRequest({
+      origin: 'http://example.com',
+      host: 'example.com',
+      'x-forwarded-proto': 'http',
+    });
+    expect(() => validateOrigin(req)).not.toThrow();
+  });
+
+  it('rejects when host header is missing and no ALLOWED_ORIGINS', () => {
+    const req = createRequest({
+      origin: 'https://example.com',
+    });
+    expect(() => validateOrigin(req)).toThrow();
+  });
+});

--- a/apps/web/src/lib/server/validate-origin.ts
+++ b/apps/web/src/lib/server/validate-origin.ts
@@ -1,0 +1,41 @@
+import { error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { dev } from '$app/environment';
+
+/**
+ * Origin / Referer ヘッダーを検証し、許可されていないリクエストを拒否する。
+ * ALLOWED_ORIGINS 環境変数（カンマ区切り）で許可オリジンを指定可能。
+ * 未設定の場合はリクエストの Host ヘッダーから自オリジンを推定して比較する。
+ */
+export function validateOrigin(request: Request): void {
+  if (dev) return;
+
+  const origin = request.headers.get('origin');
+  const referer = request.headers.get('referer');
+
+  const requestOrigin = origin ?? (referer ? new URL(referer).origin : null);
+
+  if (!requestOrigin) {
+    throw error(403, 'Forbidden');
+  }
+
+  const allowed = env.ALLOWED_ORIGINS;
+  if (allowed) {
+    const allowedList = allowed.split(',').map(o => o.trim());
+    if (allowedList.includes(requestOrigin)) return;
+    throw error(403, 'Forbidden');
+  }
+
+  // Fallback: 自オリジンとの比較
+  const host = request.headers.get('host');
+  if (!host) {
+    throw error(403, 'Forbidden');
+  }
+
+  const protocol = request.headers.get('x-forwarded-proto') ?? 'https';
+  const selfOrigin = `${protocol}://${host}`;
+
+  if (requestOrigin !== selfOrigin) {
+    throw error(403, 'Forbidden');
+  }
+}

--- a/apps/web/src/lib/server/validate-origin.ts
+++ b/apps/web/src/lib/server/validate-origin.ts
@@ -13,7 +13,14 @@ export function validateOrigin(request: Request): void {
   const origin = request.headers.get('origin');
   const referer = request.headers.get('referer');
 
-  const requestOrigin = origin ?? (referer ? new URL(referer).origin : null);
+  let requestOrigin = origin;
+  if (!requestOrigin && referer) {
+    try {
+      requestOrigin = new URL(referer).origin;
+    } catch {
+      requestOrigin = null;
+    }
+  }
 
   if (!requestOrigin) {
     throw error(403, 'Forbidden');
@@ -27,13 +34,7 @@ export function validateOrigin(request: Request): void {
   }
 
   // Fallback: 自オリジンとの比較
-  const host = request.headers.get('host');
-  if (!host) {
-    throw error(403, 'Forbidden');
-  }
-
-  const protocol = request.headers.get('x-forwarded-proto') ?? 'https';
-  const selfOrigin = `${protocol}://${host}`;
+  const selfOrigin = new URL(request.url).origin;
 
   if (requestOrigin !== selfOrigin) {
     throw error(403, 'Forbidden');

--- a/apps/web/src/routes/api/google-maps/token/+server.ts
+++ b/apps/web/src/routes/api/google-maps/token/+server.ts
@@ -1,8 +1,11 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
+import { validateOrigin } from '$lib/server/validate-origin';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
+  validateOrigin(request);
+
   const GOOGLE_MAPS_API_KEY = env.GOOGLE_MAPS_API_KEY;
   if (!GOOGLE_MAPS_API_KEY) {
     throw error(500, 'Google Maps API key not configured');

--- a/apps/web/src/routes/api/mapbox/geocode/+server.ts
+++ b/apps/web/src/routes/api/mapbox/geocode/+server.ts
@@ -1,8 +1,10 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
+import { validateOrigin } from '$lib/server/validate-origin';
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ request, url }) => {
+  validateOrigin(request);
   const query = url.searchParams.get('query');
   const lng = url.searchParams.get('lng');
   const lat = url.searchParams.get('lat');

--- a/apps/web/src/routes/api/mapbox/token/+server.ts
+++ b/apps/web/src/routes/api/mapbox/token/+server.ts
@@ -1,8 +1,11 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
+import { validateOrigin } from '$lib/server/validate-origin';
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ request }) => {
+  validateOrigin(request);
+
   const MAPBOX_ACCESS_TOKEN = env.MAPBOX_ACCESS_TOKEN;
   if (!MAPBOX_ACCESS_TOKEN) {
     throw error(500, 'Mapbox token not configured');


### PR DESCRIPTION
## Summary
- `/api/google-maps/token`, `/api/mapbox/token`, `/api/mapbox/geocode` に Origin/Referer ヘッダー検証を追加
- tabitabi サイト経由以外のリクエスト（curl、別サイト等）を 403 で拒否
- `ALLOWED_ORIGINS` 環境変数でカスタマイズ可能、dev モードではスキップ

## Test plan
- [x] `validateOrigin` のユニットテスト 9件追加（全パス）
- [ ] 本番デプロイ後、curl で直接 `/api/google-maps/token` を叩いて 403 が返ることを確認
- [ ] ブラウザから地図が今まで通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)