### PR TITLE
fix(web): リロードバグ修正 (sanitize-html を Workers SSR 互換の自前 sanitizer に置換)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.0.2",
     "@tabitabi/types": "workspace:*",
-    "mapbox-gl": "^3.17.0",
-    "sanitize-html": "^2.17.2"
+    "mapbox-gl": "^3.17.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250110.0",

--- a/apps/web/src/lib/themes/standard-seasons/shared/utils/markdown.ts
+++ b/apps/web/src/lib/themes/standard-seasons/shared/utils/markdown.ts
@@ -1,5 +1,4 @@
 import { marked } from "marked";
-import sanitizeHtml from "sanitize-html";
 import { getMemoText } from "$lib/memo";
 
 marked.setOptions({
@@ -7,23 +6,64 @@ marked.setOptions({
   gfm: true,
 });
 
-const sanitizeOptions: sanitizeHtml.IOptions = {
-  allowedTags: [
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'p', 'br', 'hr',
-    'ul', 'ol', 'li',
-    'strong', 'em', 'del', 'code', 'pre',
-    'blockquote',
-    'a',
-    'table', 'thead', 'tbody', 'tr', 'th', 'td',
-    'input',
-  ],
-  allowedAttributes: {
-    a: ['href', 'target', 'rel'],
-    input: ['type', 'checked', 'disabled'],
-  },
-  allowedSchemes: ['http', 'https', 'mailto'],
+const ALLOWED_TAGS = new Set([
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'p', 'br', 'hr',
+  'ul', 'ol', 'li',
+  'strong', 'em', 'del', 'code', 'pre',
+  'blockquote',
+  'a',
+  'table', 'thead', 'tbody', 'tr', 'th', 'td',
+  'input',
+]);
+
+const ALLOWED_ATTRS: Record<string, Set<string>> = {
+  a: new Set(['href', 'target', 'rel']),
+  input: new Set(['type', 'checked', 'disabled']),
 };
+
+// Allow http(s), mailto, root-relative, fragment, and any string with no scheme.
+// Disallow javascript:, data:, vbscript:, file:, etc.
+const SAFE_URL_RE = /^(?:https?:|mailto:|\/|#|[^:]*(?:[/?#]|$))/i;
+
+const TAG_RE = /<(\/)?\s*([a-zA-Z][\w-]*)\b((?:"[^"]*"|'[^']*'|[^>])*)>/g;
+const ATTR_RE = /([a-zA-Z_:][\w:.-]*)\s*(?:=\s*("([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
+
+function escapeQuoted(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function sanitizeAttrs(tag: string, raw: string): string {
+  const allowed = ALLOWED_ATTRS[tag];
+  if (!allowed) return '';
+  const out: string[] = [];
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(raw)) !== null) {
+    const name = m[1].toLowerCase();
+    if (!allowed.has(name)) continue;
+    const value = m[3] ?? m[4] ?? m[5] ?? '';
+    if ((name === 'href' || name === 'src') && !SAFE_URL_RE.test(value.trim())) continue;
+    out.push(`${name}="${escapeQuoted(value)}"`);
+  }
+  return out.length ? ' ' + out.join(' ') : '';
+}
+
+function sanitize(html: string): string {
+  const stripped = html
+    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, '')
+    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, '');
+  return stripped.replace(TAG_RE, (_match, slash: string | undefined, tag: string, rawAttrs: string) => {
+    const t = tag.toLowerCase();
+    if (!ALLOWED_TAGS.has(t)) return '';
+    if (slash) return `</${t}>`;
+    return `<${t}${sanitizeAttrs(t, rawAttrs)}>`;
+  });
+}
 
 const cache = new Map<string, string>();
 
@@ -35,9 +75,8 @@ export function renderMarkdown(memoOrNotes: string | null | undefined): string {
   if (cached) return cached;
 
   const raw = marked.parse(text, { async: false }) as string;
-  const result = sanitizeHtml(raw, sanitizeOptions);
+  const result = sanitize(raw);
 
-  // キャッシュサイズを制限（LRU 的に古いものから削除）
   if (cache.size > 200) {
     const firstKey = cache.keys().next().value!;
     cache.delete(firstKey);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       mapbox-gl:
         specifier: ^3.17.0
         version: 3.17.0
-      sanitize-html:
-        specifier: ^2.17.2
-        version: 2.17.2
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250110.0
@@ -2273,19 +2270,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dom-serializer@2.0.0:
-    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
-
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  domhandler@5.0.3:
-    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
-    engines: {node: '>= 4'}
-
-  domutils@3.2.2:
-    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
     engines: {node: '>=18'}
@@ -2316,16 +2300,8 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-
-  entities@7.0.1:
-    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   error-stack-parser-es@1.0.5:
@@ -2520,9 +2496,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  htmlparser2@10.1.0:
-    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
-
   http-link-header@1.1.3:
     resolution: {integrity: sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==}
     engines: {node: '>=6.0.0'}
@@ -2592,10 +2565,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2931,9 +2900,6 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  parse-srcset@1.0.2:
-    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
-
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
@@ -3176,9 +3142,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  sanitize-html@2.17.2:
-    resolution: {integrity: sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -5548,24 +5511,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dom-serializer@2.0.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      entities: 4.5.0
-
-  domelementtype@2.3.0: {}
-
-  domhandler@5.0.3:
-    dependencies:
-      domelementtype: 2.3.0
-
-  domutils@3.2.2:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-
   dot-prop@9.0.0:
     dependencies:
       type-fest: 4.41.0
@@ -5591,11 +5536,7 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
-  entities@4.5.0: {}
-
   entities@6.0.1: {}
-
-  entities@7.0.1: {}
 
   error-stack-parser-es@1.0.5: {}
 
@@ -5872,13 +5813,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  htmlparser2@10.1.0:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      entities: 7.0.1
-
   http-link-header@1.1.3: {}
 
   http-proxy-agent@7.0.2:
@@ -5942,8 +5876,6 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
-
-  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -6344,8 +6276,6 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  parse-srcset@1.0.2: {}
-
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
@@ -6589,15 +6519,6 @@ snapshots:
       mri: 1.2.0
 
   safer-buffer@2.1.2: {}
-
-  sanitize-html@2.17.2:
-    dependencies:
-      deepmerge: 4.3.1
-      escape-string-regexp: 4.0.0
-      htmlparser2: 10.1.0
-      is-plain-object: 5.0.0
-      parse-srcset: 1.0.2
-      postcss: 8.5.6
 
   saxes@6.0.0:
     dependencies:


### PR DESCRIPTION
Closes #132

## 症状

本番 (`https://tabitabi.pages.dev/<id>`) でしおり詳細ページがリロードできない。
- 同一 URL を連打すると 404 と 500 が交互に返る
- DB にしおりは保存されている、API 単体 (`/api/v1/itineraries/<id>`) は 200

## 原因 (ローカルで再現・特定)

SSR (`+page.ts` の `load()`) が以下の例外で死んでいた:
\`\`\`
Dynamic require of \"node:path\" is not supported
\`\`\`

チェーン: `markdown.ts` → `sanitize-html` → `postcss/lib/previous-map.js`
postcss が `__require(\"node:path\")` を eager 評価するが、esbuild の `__require` shim は `typeof require !== \"undefined\"` をランタイムでチェックする。Cloudflare Workers ESM 環境では `nodejs_compat` フラグや compat date を上げてもグローバル `require` は生えないため必ず throw する。

検証: `--compatibility-date 2024-09-23` / `2025-08-01` でローカル `wrangler pages dev` 実行、いずれも同じ 500 で再現。compat date による回避は不可能。

`load()` 1回目: dynamic import の例外が catch に届き `error(404)` → 404
`load()` 2回目以降: モジュールキャッシュに undefined が定着、SSR が `data.theme.components` 参照時に 500
…という形で 404/500 が混ざっていた。

## 修正

`sanitize-html` (および transitive な postcss/htmlparser2 等) を依存から外し、同等の allowlist ベースの sanitizer を `markdown.ts` 内に直接実装。

- 許可タグ・属性・URL スキームは従来の `sanitizeOptions` と同一
- `<script>` / `<style>` はブロックごと除去
- `href` / `src` は `http(s):` / `mailto:` / 相対 / フラグメントのみ通す
- 入力ベースの memoization (上限 200 件) は維持

## 検証

- 既存テスト 7 件全部パス (`pnpm test:run markdown.test.ts`)
- ローカル `wrangler pages dev` で `/<id>` に 5/5 で 200
- 他主要ページ (/, /demo, /itineraries, /users, /profile) も 200

## Test plan
- [ ] CI 緑
- [ ] preview 環境にデプロイし `/<新規作成したしおりの id>` をリロード × 数回、200 が続くこと
- [ ] 別ブラウザ (シークレットウィンドウなど) で同 URL を開いて 200
- [ ] メモに markdown 入れて表示崩れ・XSS が無いことを確認