### PR TITLE
Create per-preview D1 databases and apply migrations for preview workflows

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -14,6 +14,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      PREVIEW_DB_NAME: tabitabi-preview-pr-${{ github.event.pull_request.number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,6 +36,11 @@ jobs:
         run: |
           WORKER_NAME="tabitabi-api-preview-pr-${PR_NUMBER}"
           pnpm wrangler delete --name "${WORKER_NAME}" || echo "Worker may not exist"
+        continue-on-error: true
+
+      - name: Delete Preview D1 Database
+        run: |
+          pnpm wrangler d1 delete "${PREVIEW_DB_NAME}" --skip-confirmation || echo "Preview database may not exist"
         continue-on-error: true
 
       - name: Cleanup Pages preview deployments

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,8 +29,8 @@ jobs:
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_DATABASE_ID: ${{ secrets.CLOUDFLARE_DATABASE_ID }}
       PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.issue.number }}
+      PREVIEW_DB_NAME: tabitabi-preview-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.issue.number }}
     steps:
       - name: Add reaction to comment
         if: github.event_name == 'issue_comment'
@@ -74,16 +74,45 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Delete existing preview D1 database
+        run: |
+          pnpm wrangler d1 delete "${PREVIEW_DB_NAME}" --skip-confirmation || echo "Preview database may not exist"
+
+      - name: Create preview D1 database
+        id: preview-db
+        run: |
+          set -euo pipefail
+          OUTPUT=$(pnpm wrangler d1 create "${PREVIEW_DB_NAME}" 2>&1)
+          echo "$OUTPUT"
+
+          DATABASE_ID=$(printf '%s\n' "$OUTPUT" | sed -nE 's/.*database_id = "([^"]+)".*/\1/p' | head -1)
+          if [ -z "$DATABASE_ID" ]; then
+            DATABASE_ID=$(printf '%s\n' "$OUTPUT" | grep -Eo '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' | head -1)
+          fi
+
+          if [ -z "$DATABASE_ID" ]; then
+            echo "Failed to parse preview D1 database ID from wrangler output" >&2
+            exit 1
+          fi
+
+          echo "database_id=${DATABASE_ID}" >> "$GITHUB_OUTPUT"
+
       - name: Generate wrangler.toml from example
         run: |
           cp wrangler.toml.example wrangler.toml
-          sed -i "s/PLACEHOLDER_DATABASE_ID/${CLOUDFLARE_DATABASE_ID}/g" wrangler.toml
+          sed -i "s/PLACEHOLDER_DATABASE_ID/${{ steps.preview-db.outputs.database_id }}/g" wrangler.toml
+          sed -i "s/database_name = \"tabitabi\"/database_name = \"${PREVIEW_DB_NAME}\"/g" wrangler.toml
 
       - name: Generate API wrangler.toml from example
         working-directory: apps/api
         run: |
           cp wrangler.toml.example wrangler.toml
-          sed -i "s/PLACEHOLDER_DATABASE_ID/${CLOUDFLARE_DATABASE_ID}/g" wrangler.toml
+          sed -i "s/PLACEHOLDER_DATABASE_ID/${{ steps.preview-db.outputs.database_id }}/g" wrangler.toml
+          sed -i "s/database_name = \"tabitabi\"/database_name = \"${PREVIEW_DB_NAME}\"/g" wrangler.toml
+
+      - name: Apply D1 migrations to preview database
+        working-directory: apps/api
+        run: pnpm wrangler d1 migrations apply DB --remote --env preview
 
       - name: Deploy API to preview environment
         working-directory: apps/api
@@ -124,11 +153,11 @@ jobs:
 
             - **Web App**: ${webUrl}
             - **API**: ${apiUrl}
+            - **D1 Database**: \`${process.env.PREVIEW_DB_NAME}\`
 
             The Web app is configured to access the preview API automatically.
             To update this preview, comment \`/deploy-preview\` again.
-
-            > **Note**: Preview environments share the same database as production.`;
+            `;
 
             github.rest.issues.createComment({
               issue_number: process.env.PR_NUMBER,


### PR DESCRIPTION
### Motivation
- Prevent preview environments from using the production D1 database by creating a dedicated D1 database per PR preview.
- Ensure each preview database receives the same schema as production by applying migrations to the preview DB before deploying the preview Worker.
- Automatically remove preview databases when a PR is closed to avoid orphaned preview data and costs.

### Description
- Add a `PREVIEW_DB_NAME` env var and create a preview-scoped D1 database named `tabitabi-preview-pr-<PR_NUMBER>` in `.github/workflows/preview.yml`.
- Parse the created D1 database ID and inject it into generated `wrangler.toml` files and replace the `database_name` with the preview DB name for both root and `apps/api` configs.
- Apply D1 migrations to the preview database with `pnpm wrangler d1 migrations apply DB --remote --env preview` before deploying the preview API Worker.
- Add cleanup in `.github/workflows/cleanup-preview.yml` to delete the preview D1 database on PR close using `pnpm wrangler d1 delete "${PREVIEW_DB_NAME}" --skip-confirmation`.

### Testing
- Validated that both modified workflows parse as YAML using `ruby -e 'require "yaml"; %w[.github/workflows/preview.yml .github/workflows/cleanup-preview.yml].each { |f| YAML.load_file(f); puts "OK #{f}" }'`, and the check succeeded after fixing a quoting issue.
- Ran `git diff --check` to ensure no whitespace or trivial issues were introduced and it succeeded.
- Verified the workflow lines that create/apply/delete D1 databases and the `wrangler.toml` substitutions by inspecting the updated workflow files locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184b6abdb4832f82a6503cfe104a01)